### PR TITLE
Add maintainability and operations framework

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Ownership for review routing. Keep this short - we want real reviewers, not
+# rubber stamps.
+
+# Framework & docs: any maintainer.
+/AGENTS.md
+/CONTRIBUTING.md
+/docs/                       @SUNY-Brockport-ACM-Student-Chapter/maintainers
+
+# Production-sensitive: ops + a code reviewer.
+/docs/ops/                   @SUNY-Brockport-ACM-Student-Chapter/maintainers
+/docs/PRODUCTION_ENVIRONMENT.md  @SUNY-Brockport-ACM-Student-Chapter/maintainers
+/scripts/                    @SUNY-Brockport-ACM-Student-Chapter/maintainers
+
+# App code: maintainers. When a frontend team exists, split this.
+/app/                        @SUNY-Brockport-ACM-Student-Chapter/maintainers
+
+# CI + templates change how everyone works - require review.
+/.github/                    @SUNY-Brockport-ACM-Student-Chapter/maintainers

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,73 @@
+name: Bug report
+description: Report a defect. Full template is in docs/templates/BUG.md.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If production is broken right now, follow
+        [`docs/ops/SOP_INCIDENT.md`](../../docs/ops/SOP_INCIDENT.md) first and open this issue afterwards.
+
+  - type: textarea
+    id: tldr
+    attributes:
+      label: TL;DR
+      description: One sentence - what's wrong.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: env
+    attributes:
+      label: Environment
+      options:
+        - "Local dev"
+        - "Production (access.brockportsigai.org)"
+        - "Older prod instance (35.196.195.118)"
+        - "Other (describe in Repro)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Repro steps
+      description: Numbered steps. Include the input .pptx filename / source if relevant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_actual
+    attributes:
+      label: Expected vs actual
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence (traceback, screenshot, journalctl excerpt)
+      render: text
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - "S1 - prod down / data loss"
+        - "S2 - major feature broken"
+        - "S3 - minor feature broken / workaround exists"
+        - "S4 - cosmetic / dev-only"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: pre
+    attributes:
+      label: Before submitting
+      options:
+        - label: I confirmed this reproduces on the tip of the target branch.
+        - label: I checked [`docs/ops/SOP_INCIDENT.md`](../../docs/ops/SOP_INCIDENT.md) symptom matrix.
+        - label: No secret value is pasted in this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Production incident
+    url: https://github.com/SUNY-Brockport-ACM-Student-Chapter/Student-Accessible-Powerpoint/blob/main/docs/ops/SOP_INCIDENT.md
+    about: If prod is down right now, open the SOP and follow it. Log the incident afterwards in docs/ops/INCIDENT_LOG.md.
+  - name: Agent onboarding
+    url: https://github.com/SUNY-Brockport-ACM-Student-Chapter/Student-Accessible-Powerpoint/blob/main/AGENTS.md
+    about: If you are an AI agent picking up this project, start here.
+  - name: Human onboarding
+    url: https://github.com/SUNY-Brockport-ACM-Student-Chapter/Student-Accessible-Powerpoint/blob/main/CONTRIBUTING.md
+    about: Developer onboarding guide.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,78 @@
+name: Feature request
+description: Propose a new capability. Full spec is in docs/templates/FEATURE.md.
+title: "[feat] "
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the proposal. The full agent-optimized template lives at
+        [`docs/templates/FEATURE.md`](../../docs/templates/FEATURE.md) — copy and paste it into the
+        description once this issue is created if you want a reviewer to pick it up.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary (<= 3 sentences)
+      description: What does the user gain when this ships?
+      placeholder: "Users can upload .docx files alongside .pptx and get the same accessibility treatment."
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Who asked for this, why now, what evidence?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: branch
+    attributes:
+      label: Likely target branch
+      options:
+        - "main (canonical)"
+        - "Aggrement (production)"
+        - "Prod-v1 (Docker)"
+        - "nextjs-impl (experimental)"
+        - "unsure"
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope - in / out
+      description: Bullets for "in scope" and "out of scope". Be strict about out-of-scope.
+    validations:
+      required: true
+
+  - type: textarea
+    id: invariants
+    attributes:
+      label: Which invariants does this touch?
+      description: |
+        List any of the invariants from
+        [`docs/guardrails/INVARIANTS.md`](../../docs/guardrails/INVARIANTS.md) that this change
+        intersects (e.g. #1 order_number, #2 cNvPr/descr, #3 Gemini backoff, #4 Chroma wrapper,
+        #5 image norm, #6 chroma data, #7 group traversal, #8 consent gate).
+      placeholder: "#1 order_number (adds a new SlideItem subclass), #4 Chroma wrapper (new endpoint)"
+
+  - type: textarea
+    id: a11y
+    attributes:
+      label: Accessibility (WCAG 2.1 AA) impact
+      description: Does this affect alt text, reading order, contrast, color reliance?
+
+  - type: checkboxes
+    id: pre
+    attributes:
+      label: Before submitting
+      options:
+        - label: I read [`AGENTS.md`](../../AGENTS.md) / [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
+          required: true
+        - label: I reviewed the reference implementation in [`docs/AGENT_CONTEXT.md`](../../docs/AGENT_CONTEXT.md).
+          required: true
+        - label: I will fill out [`docs/templates/FEATURE.md`](../../docs/templates/FEATURE.md) in full when the PR is opened.
+          required: true

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,53 @@
+name: Refactor
+description: Structural change with no behavior change. Full template is in docs/templates/REFACTOR.md.
+title: "[refactor] "
+labels: ["refactor"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Strict rule:** a refactor does not change behavior. If it does, this is a Feature or a Bug fix,
+        not a refactor. Be honest with yourself here.
+
+  - type: textarea
+    id: tldr
+    attributes:
+      label: TL;DR
+      description: What structural thing changes, and why behavior stays identical.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: motivation
+    attributes:
+      label: Motivation (pick at least one)
+      options:
+        - label: Closes a tech-debt item from [`docs/guardrails/INVARIANTS.md`](../../docs/guardrails/INVARIANTS.md) section 10
+        - label: Unblocks a planned feature
+        - label: Reduces a footgun from [`docs/AGENT_CONTEXT.md`](../../docs/AGENT_CONTEXT.md)
+        - label: Encodes an invariant in code (not just docs)
+        - label: Other (describe below)
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: In scope (structural) and out of scope (must include "any behavior change").
+    validations:
+      required: true
+
+  - type: textarea
+    id: equivalence
+    attributes:
+      label: How will we know behavior is unchanged?
+      description: Tests, round-trip parity, smoke test, manual comparison.
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: pre
+    attributes:
+      label: Before submitting
+      options:
+        - label: I walked through every invariant in [`docs/guardrails/INVARIANTS.md`](../../docs/guardrails/INVARIANTS.md) and can explain why each still holds.
+          required: true

--- a/.github/ISSUE_TEMPLATE/update.yml
+++ b/.github/ISSUE_TEMPLATE/update.yml
@@ -1,0 +1,68 @@
+name: Update / dependency bump
+description: Version bump, dep update, config tweak. Full template is in docs/templates/UPDATE.md.
+title: "[update] "
+labels: ["update"]
+body:
+  - type: textarea
+    id: tldr
+    attributes:
+      label: TL;DR
+      description: What's being updated and why.
+    validations:
+      required: true
+
+  - type: input
+    id: change
+    attributes:
+      label: Package / model / config + from -> to
+      placeholder: "chromadb 1.5.7 -> 1.6.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: trigger
+    attributes:
+      label: Trigger
+      options:
+        - "Security advisory / CVE"
+        - "Upstream deprecation"
+        - "Feature we need"
+        - "Routine maintenance"
+        - "Sysadmin request"
+        - "Other"
+    validations:
+      required: true
+
+  - type: input
+    id: advisory
+    attributes:
+      label: Reference link (CVE, release notes, etc.)
+
+  - type: dropdown
+    id: branches
+    attributes:
+      label: Branches to update
+      multiple: true
+      options:
+        - "main"
+        - "Aggrement"
+        - "Prod-v1"
+        - "nextjs-impl"
+    validations:
+      required: true
+
+  - type: textarea
+    id: risk
+    attributes:
+      label: Compatibility risks
+      description: Breaking changes, deprecations, invariants touched.
+
+  - type: checkboxes
+    id: pre
+    attributes:
+      label: Before submitting
+      options:
+        - label: I read the upstream changelog from current -> proposed version.
+          required: true
+        - label: I identified which invariants this could affect ([`docs/guardrails/INVARIANTS.md`](../../docs/guardrails/INVARIANTS.md)).
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,92 @@
+<!--
+Thanks for contributing to Student-Accessible-Powerpoint.
+
+Before you open this PR:
+  1. You MUST have read AGENTS.md (agents) or CONTRIBUTING.md (humans).
+  2. Replace the TL;DR below and fill out the change template that matches.
+  3. Fill out the pre-merge checklist at the bottom.
+
+Pick ONE template below and DELETE the others + this HTML comment.
+
+  - New capability            -> docs/templates/FEATURE.md
+  - Dependency / version bump -> docs/templates/UPDATE.md
+  - Bug fix                   -> docs/templates/BUG.md
+  - Structural / no behavior  -> docs/templates/REFACTOR.md
+-->
+
+## TL;DR
+
+<!-- One sentence: what does this PR do and why. -->
+
+## Change type
+
+- [ ] Feature (copy structure from [`docs/templates/FEATURE.md`](../docs/templates/FEATURE.md))
+- [ ] Update / dependency bump (copy structure from [`docs/templates/UPDATE.md`](../docs/templates/UPDATE.md))
+- [ ] Bug fix (copy structure from [`docs/templates/BUG.md`](../docs/templates/BUG.md))
+- [ ] Refactor (copy structure from [`docs/templates/REFACTOR.md`](../docs/templates/REFACTOR.md))
+- [ ] Docs only
+
+## Target branch
+
+- [ ] `main` (canonical)
+- [ ] `Aggrement` (production)
+- [ ] `Prod-v1` (Docker)
+- [ ] Other: …
+
+See [`docs/guardrails/BRANCHING.md`](../docs/guardrails/BRANCHING.md) for the policy.
+
+---
+
+## Change template (paste the filled-out template here)
+
+<!-- Replace this block with your chosen template, fully filled out. -->
+
+---
+
+## Pre-merge checklist
+
+Full form in [`docs/guardrails/CHANGE_CHECKLIST.md`](../docs/guardrails/CHANGE_CHECKLIST.md). Tick each or write `N/A - reason`.
+
+**Intent**
+- [ ] Correct change template pasted above
+- [ ] Correct target branch selected
+
+**Invariants** ([`docs/guardrails/INVARIANTS.md`](../docs/guardrails/INVARIANTS.md))
+- [ ] No invariant violated
+- [ ] #1 `order_number` preserved (if parsing/rebuild touched)
+- [ ] #2 `cNvPr/@descr` preserved (if alt-text touched)
+- [ ] #3 60s Gemini backoff preserved (if Gemini touched)
+- [ ] #4 Chroma wrapper preserved (if Chroma touched)
+- [ ] #5 Image normalization preserved (if images touched)
+- [ ] #8 Consent gate preserved (if on `Aggrement`)
+
+**Local validation**
+- [ ] `python scripts/doctor.py` passes
+- [ ] `python scripts/check_invariants.py` passes
+- [ ] `python scripts/preflight.py` passes
+- [ ] `python -m pytest -q` passes (or N/A)
+- [ ] Manual three-process run + `.pptx` round-trip succeeded (or N/A)
+
+**Accessibility (WCAG 2.1 AA)**
+- [ ] No regression in alt-text quality or reading order
+- [ ] PowerPoint Accessibility Checker spot-check on output deck (or N/A)
+
+**Dependencies & config**
+- [ ] New Python deps added to `requirements.txt` and (if UI) `requirements-app.txt`
+- [ ] New env vars added to `.env.example` and [`docs/AGENT_CONTEXT.md`](../docs/AGENT_CONTEXT.md)
+- [ ] Secrets NOT committed
+
+**Production safety**
+- [ ] If prod deploy needed: plan follows [`docs/ops/SOP_DEPLOY.md`](../docs/ops/SOP_DEPLOY.md)
+- [ ] Rollback SHA identified (recorded at deploy time)
+- [ ] Breaking change labelled, if applicable
+
+**Docs**
+- [ ] [`docs/AGENT_CONTEXT.md`](../docs/AGENT_CONTEXT.md) updated (if behavior changed)
+- [ ] [`docs/PROJECT_OVERVIEW.md`](../docs/PROJECT_OVERVIEW.md) updated (if narrative changed)
+- [ ] [`docs/PRODUCTION_ENVIRONMENT.md`](../docs/PRODUCTION_ENVIRONMENT.md) updated (if infra changed)
+- [ ] New invariant added to [`docs/guardrails/INVARIANTS.md`](../docs/guardrails/INVARIANTS.md) (if applicable)
+
+**Tests**
+- [ ] At least one test added (or explicit N/A with justification)
+- [ ] [`scripts/smoke_test.py`](../scripts/smoke_test.py) updated if a URL/endpoint/health indicator changed

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -97,16 +97,17 @@ jobs:
             cat invariants.out
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
-          # Mirror every output line into workflow annotations so the failure
-          # text is visible via the public annotations API (unlike job logs
-          # and step summaries, which require auth).
-          python - <<'PY'
-          import pathlib, urllib.parse
+          # On failure only, mirror output into a workflow annotation so the
+          # failure text is visible via the public annotations API (job logs
+          # and step summaries both require auth to read).
+          if [ "$rc" -ne 0 ]; then
+            python - <<'PY'
+          import pathlib
           txt = pathlib.Path('invariants.out').read_text(encoding='utf-8', errors='replace')
           enc = txt.replace('%','%25').replace('\r','%0D').replace('\n','%0A')
-          # 4KB is the hard cap on a single annotation body.
           print(f"::error title=check_invariants output::{enc[:3500]}")
           PY
+          fi
           exit $rc
 
       - name: Preflight aggregate

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     branches: [main, Aggrement, Prod-v1]
   push:
-    branches: [main, Aggrement]
+    branches: [main, Aggrement, "feature/**"]
 
 permissions:
   contents: read
@@ -22,27 +22,95 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
           cache: pip
 
+      - name: Environment diagnostics
+        shell: bash
+        run: |
+          {
+            echo "## Environment"
+            echo ''
+            echo '```'
+            echo "python: $(python --version)"
+            echo "pip:    $(pip --version)"
+            echo "git:    $(git --version)"
+            echo "os:     $(uname -a)"
+            echo "pwd:    $(pwd)"
+            echo '```'
+            echo ''
+            echo "## Repo file tree (top 40)"
+            echo ''
+            echo '```'
+            ls -la | head -n 40
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Install runtime deps (best-effort)
-        # If pip install fails (e.g. optional OS-level dep missing), the
-        # preflight import-smoke will still run and degrade gracefully.
+        # Deps missing -> preflight import-smoke degrades to WARN, not FAIL.
+        shell: bash
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt || true
+          pip install -r requirements.txt 2>&1 | tee pip-install.log || true
+          pip install pytest 2>&1 | tee -a pip-install.log || true
+          {
+            echo "## pip install (tail)"
+            echo ''
+            echo '```'
+            tail -n 20 pip-install.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
         continue-on-error: true
 
       - name: Doctor (environment sanity)
-        run: python scripts/doctor.py
+        id: doctor
+        shell: bash
+        run: |
+          set +e
+          python scripts/doctor.py 2>&1 | tee doctor.out
+          rc=${PIPESTATUS[0]}
+          {
+            echo "## doctor.py (exit=$rc)"
+            echo ''
+            echo '```'
+            cat doctor.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $rc
 
       - name: Check invariants
-        run: python scripts/check_invariants.py
+        id: invariants
+        shell: bash
+        run: |
+          set +e
+          python scripts/check_invariants.py 2>&1 | tee invariants.out
+          rc=${PIPESTATUS[0]}
+          {
+            echo "## check_invariants.py (exit=$rc)"
+            echo ''
+            echo '```'
+            cat invariants.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $rc
 
       - name: Preflight aggregate
-        run: python scripts/preflight.py
+        id: preflight
+        shell: bash
+        run: |
+          set +e
+          python scripts/preflight.py 2>&1 | tee preflight.out
+          rc=${PIPESTATUS[0]}
+          {
+            echo "## preflight.py (exit=$rc)"
+            echo ''
+            echo '```'
+            tail -n 120 preflight.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $rc

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,0 +1,48 @@
+name: preflight
+
+# Runs the same gate a developer runs locally before opening a PR.
+# Closes the "no CI/CD" gap listed in docs/guardrails/INVARIANTS.md section 10.6.
+#
+# Keep this workflow cheap: no Gemini calls, no Chroma server, no deploy.
+# Integration / smoke tests against prod run manually via scripts/smoke_test.py
+# after SOP_DEPLOY.md.
+
+on:
+  pull_request:
+    branches: [main, Aggrement, Prod-v1]
+  push:
+    branches: [main, Aggrement]
+
+permissions:
+  contents: read
+
+jobs:
+  preflight:
+    name: doctor + invariants + import smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install runtime deps (best-effort)
+        # If pip install fails (e.g. optional OS-level dep missing), the
+        # preflight import-smoke will still run and degrade gracefully.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt || true
+        continue-on-error: true
+
+      - name: Doctor (environment sanity)
+        run: python scripts/doctor.py
+
+      - name: Check invariants
+        run: python scripts/check_invariants.py
+
+      - name: Preflight aggregate
+        run: python scripts/preflight.py

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -97,6 +97,16 @@ jobs:
             cat invariants.out
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+          # Mirror every output line into workflow annotations so the failure
+          # text is visible via the public annotations API (unlike job logs
+          # and step summaries, which require auth).
+          python - <<'PY'
+          import pathlib, urllib.parse
+          txt = pathlib.Path('invariants.out').read_text(encoding='utf-8', errors='replace')
+          enc = txt.replace('%','%25').replace('\r','%0D').replace('\n','%0A')
+          # 4KB is the hard cap on a single annotation body.
+          print(f"::error title=check_invariants output::{enc[:3500]}")
+          PY
           exit $rc
 
       - name: Preflight aggregate

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,125 @@
+# AGENTS.md — Entry Point for AI Agents
+
+> **You are an AI agent working on this repository.** Read this file first. It points you at everything else and lists the small number of rules that must never be broken.
+
+---
+
+## 1. What this project is (30 seconds)
+
+A Streamlit + RAG pipeline that takes a `.pptx` upload, generates ADA-compliant alt text (native `cNvPr/@descr` XML) and AI-enhanced speaker notes using Google Gemini + ChromaDB, and returns a downloadable accessible deck. Python 3.11. See [`docs/PROJECT_OVERVIEW.md`](docs/PROJECT_OVERVIEW.md) for the human narrative.
+
+**Live production:** `https://access.brockportsigai.org/accessibility` (branch `Aggrement`, bare-metal systemd on GCP). See [`docs/PRODUCTION_ENVIRONMENT.md`](docs/PRODUCTION_ENVIRONMENT.md).
+
+---
+
+## 2. Your reading order (always, in this order)
+
+1. **This file** — invariants + routing
+2. [`docs/AGENT_CONTEXT.md`](docs/AGENT_CONTEXT.md) — dense technical reference (data model, control flow, branches, foot-guns)
+3. [`docs/guardrails/INVARIANTS.md`](docs/guardrails/INVARIANTS.md) — things that will silently break if violated
+4. The template that matches your change type (§4 below)
+5. [`docs/PROJECT_OVERVIEW.md`](docs/PROJECT_OVERVIEW.md) or [`docs/PRODUCTION_ENVIRONMENT.md`](docs/PRODUCTION_ENVIRONMENT.md) — only if the task needs them
+
+Do **not** skim — a lot of this codebase relies on non-obvious invariants (see §3).
+
+---
+
+## 3. Hard invariants (violation = breakage)
+
+Full list with rationale in [`docs/guardrails/INVARIANTS.md`](docs/guardrails/INVARIANTS.md). Short form:
+
+1. **`order_number` is the universal key** between parsed items and `.pptx` shapes. If you touch parsing, rebuilding, or any loop over `slide.shapes`/`slide.items`, preserve `order_number` exactly. Changing shape order during rebuild = alt text assigned to the wrong shape.
+2. **Alt text goes on `cNvPr/@descr`** (native XML attribute), with `shape.alternative_text` as the fallback write. Screen readers use the XML attribute; `python-pptx`'s property alone is not enough.
+3. **Never block the Streamlit event loop** with Gemini calls on the main thread without a spinner/progress UI — users stare at 0 % for minutes otherwise.
+4. **Gemini rate-limit: sleep 60 s** on `ResourceExhausted` / 429. Do not reduce this; production will hit daily quota during a demo otherwise.
+5. **ChromaDB access is via HTTP to `chroma-api`**, not direct `chromadb.Client()` from the Streamlit process. Keep the FastAPI wrapper in the path.
+6. **Image normalization**: WMF/EMF + PIL "P" mode must be converted to PNG/RGB before hashing or sending to Gemini, or you get opaque base64 errors.
+7. **No writes to `chroma/` inside the repo tree in production** — the prod server stores vector data at `./chroma/`. A `git clean -fdx` wipes it. Do not add it to `.gitignore` changes without reading [`docs/guardrails/INVARIANTS.md`](docs/guardrails/INVARIANTS.md) §6.
+8. **Branch discipline**: `main` = clean codebase of record; `Aggrement` = what production runs; `Prod-v1` = Dockerized variant; `nextjs-impl` = experimental. Never merge these laterally without a migration plan — see [`docs/guardrails/BRANCHING.md`](docs/guardrails/BRANCHING.md).
+9. **Consent gate is IRB-mandated** (Aggrement branch). Do not bypass, shorten, or remove the consent screen without an IRB amendment.
+10. **Secrets never in git.** `.env` is gitignored; production's `.env` is a separate artifact.
+
+---
+
+## 4. Choose a template before you start coding
+
+| Change type | Template | Typical scope |
+|---|---|---|
+| New capability | [`docs/templates/FEATURE.md`](docs/templates/FEATURE.md) | new UI screen, new file type, new model |
+| Dependency bump / version change | [`docs/templates/UPDATE.md`](docs/templates/UPDATE.md) | `requirements*.txt`, Python version, Gemini model |
+| Defect fix | [`docs/templates/BUG.md`](docs/templates/BUG.md) | incorrect alt text, crash, UX regression |
+| Structural / no behavior change | [`docs/templates/REFACTOR.md`](docs/templates/REFACTOR.md) | module split, renames, typing |
+
+Copy the template into the PR description (or the issue). Fill it out *before* writing code. The template exists so the reviewer and the next agent can reconstruct your intent in 60 seconds.
+
+---
+
+## 5. Pre-flight, tests, and merge gate
+
+Before pushing:
+
+```bash
+python scripts/doctor.py       # env + layout sanity (offline, fast)
+python scripts/preflight.py    # run this before opening a PR
+python -m pytest -q            # unit tests
+python scripts/check_invariants.py   # static invariant checks
+```
+
+After deploying to production (`docs/ops/SOP_DEPLOY.md`):
+
+```bash
+python scripts/smoke_test.py --url https://access.brockportsigai.org/accessibility
+```
+
+Full checklist: [`docs/guardrails/CHANGE_CHECKLIST.md`](docs/guardrails/CHANGE_CHECKLIST.md).
+
+---
+
+## 6. Operations — you are also the ops team
+
+| Task | SOP |
+|---|---|
+| Ship a change to prod | [`docs/ops/SOP_DEPLOY.md`](docs/ops/SOP_DEPLOY.md) |
+| Back out a bad deploy | [`docs/ops/SOP_ROLLBACK.md`](docs/ops/SOP_ROLLBACK.md) |
+| Prod is down / broken | [`docs/ops/SOP_INCIDENT.md`](docs/ops/SOP_INCIDENT.md) |
+| Rotate the Gemini key | [`docs/ops/SOP_SECRETS.md`](docs/ops/SOP_SECRETS.md) |
+
+Production access requires `gcloud auth` credentials with `compute.instances.setMetadata` on `instance-20250905-023343-pub` (zone `us-central1-c`). Only three instances are SSH-accessible to current operators — see [`docs/PRODUCTION_ENVIRONMENT.md`](docs/PRODUCTION_ENVIRONMENT.md) §2.
+
+---
+
+## 7. Things you are *not* allowed to do unprompted
+
+- Commit without the user asking.
+- Push force to any shared branch.
+- `git clean -fdx` or `rm -rf chroma/` on the production VM.
+- Edit files directly on the production VM (edit in git, deploy via SOP).
+- Change the Gemini model without a dedicated [`UPDATE.md`](docs/templates/UPDATE.md) request.
+- Add a new public nginx route without updating [`docs/PRODUCTION_ENVIRONMENT.md`](docs/PRODUCTION_ENVIRONMENT.md) + firewall review.
+- Remove or weaken the consent gate (IRB).
+- Widen the GCP firewall.
+- Expose `.env` in logs, PRs, or screenshots.
+
+---
+
+## 8. When the docs contradict the code
+
+The running code is always authoritative for *behavior*; the docs are authoritative for *intent*. If you find a contradiction:
+
+1. Read the git history on the contradicting file.
+2. Open an issue with the [`docs/templates/BUG.md`](docs/templates/BUG.md) template labeled `docs-drift`.
+3. Fix the smaller of (code, docs) to match the other. Prefer fixing docs unless there's clear bug evidence.
+
+---
+
+## 9. Quick links
+
+- Human onboarding: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Dense tech reference: [`docs/AGENT_CONTEXT.md`](docs/AGENT_CONTEXT.md)
+- Live environment: [`docs/PRODUCTION_ENVIRONMENT.md`](docs/PRODUCTION_ENVIRONMENT.md)
+- Invariants: [`docs/guardrails/INVARIANTS.md`](docs/guardrails/INVARIANTS.md)
+- Branching: [`docs/guardrails/BRANCHING.md`](docs/guardrails/BRANCHING.md)
+- Pre-merge checklist: [`docs/guardrails/CHANGE_CHECKLIST.md`](docs/guardrails/CHANGE_CHECKLIST.md)
+- Ops SOPs: [`docs/ops/`](docs/ops/)
+- Templates: [`docs/templates/`](docs/templates/)
+- Scripts: [`scripts/`](scripts/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing to Student-Accessible-Powerpoint
+
+Welcome. This document is the human onboarding path. AI agents should start at [`AGENTS.md`](AGENTS.md) instead (and then this file afterwards).
+
+---
+
+## 1. One-page orientation
+
+- **What it is**: A Streamlit web app that makes PowerPoint decks ADA-compliant (WCAG 2.1 AA) by generating alt text and speaker notes via Google Gemini + a RAG pipeline over ChromaDB.
+- **What lives where**: Full map in [`docs/PROJECT_OVERVIEW.md`](docs/PROJECT_OVERVIEW.md). Dense agent-oriented reference in [`docs/AGENT_CONTEXT.md`](docs/AGENT_CONTEXT.md).
+- **Where it runs**: Production is on a single GCP VM under systemd. See [`docs/PRODUCTION_ENVIRONMENT.md`](docs/PRODUCTION_ENVIRONMENT.md).
+- **How changes flow**: local dev → PR against `main` → manual deploy to prod (we do **not** deploy `main` directly; see [Branching](docs/guardrails/BRANCHING.md)).
+
+---
+
+## 2. Local setup (10 minutes)
+
+Prerequisites: Python 3.11.x, git, a Google Gemini API key.
+
+```bash
+git clone https://github.com/SUNY-Brockport-ACM-Student-Chapter/Student-Accessible-Powerpoint.git
+cd Student-Accessible-Powerpoint
+python -m venv venv
+
+# Windows (PowerShell)
+venv\Scripts\Activate.ps1
+# macOS / Linux
+source venv/bin/activate
+
+pip install -r requirements.txt
+cp .env.example .env        # then paste your GOOGLE_API_KEY
+python scripts/doctor.py    # sanity check your environment
+```
+
+Run the full stack (three processes):
+
+```bash
+# Terminal 1 — ChromaDB (vector store)
+venv/bin/chroma run --path ./chroma
+
+# Terminal 2 — FastAPI wrapper
+python app/chroma-api/app.py
+
+# Terminal 3 — Streamlit UI
+streamlit run app/ppt_notes.py
+```
+
+Open http://localhost:8501 . Upload any `.pptx`. If it crashes, check the three terminals — the Gemini key is the usual culprit.
+
+> **Shortcut**: `python start_app.py` starts Chroma + Streamlit together (dev only; production uses systemd).
+
+---
+
+## 3. Making a change
+
+1. **Pick a change type** and read the matching template:
+   - New capability → [`docs/templates/FEATURE.md`](docs/templates/FEATURE.md)
+   - Version bump / dep update → [`docs/templates/UPDATE.md`](docs/templates/UPDATE.md)
+   - Bug fix → [`docs/templates/BUG.md`](docs/templates/BUG.md)
+   - Restructure without behavior change → [`docs/templates/REFACTOR.md`](docs/templates/REFACTOR.md)
+
+2. **Branch** from `main`:
+
+   ```bash
+   git checkout main && git pull
+   git checkout -b feat/<short-slug>     # or fix/, chore/, refactor/
+   ```
+
+3. **Read the invariants** in [`docs/guardrails/INVARIANTS.md`](docs/guardrails/INVARIANTS.md) *before* touching parsing, rebuild, or Gemini calls.
+
+4. **Code**. Favor small PRs. No new dependency without adding it to both `requirements.txt` and `requirements-app.txt` if the Streamlit UI uses it.
+
+5. **Run the pre-merge gate**:
+
+   ```bash
+   python scripts/doctor.py
+   python scripts/check_invariants.py
+   python -m pytest -q
+   python scripts/preflight.py
+   ```
+
+6. **Open a PR** against `main`. The PR template will prompt you to paste the filled-out change template.
+
+7. **Deploy** only after merge. Follow [`docs/ops/SOP_DEPLOY.md`](docs/ops/SOP_DEPLOY.md). The deploy is manual and gated on the smoke test.
+
+---
+
+## 4. Style & conventions
+
+- **Python**: 3.11. Type hints on new public functions. `snake_case`. Docstrings on any function that crosses a module boundary.
+- **No lateral commits to `Aggrement` or `Prod-v1`** without an accompanying cherry-pick plan — those are deployment branches, not feature branches. Details: [`docs/guardrails/BRANCHING.md`](docs/guardrails/BRANCHING.md).
+- **No comments that narrate the code.** Comments explain *why*, not *what*.
+- **Env vars**: new variables go in `.env.example` with a placeholder and in [`docs/AGENT_CONTEXT.md`](docs/AGENT_CONTEXT.md) "Stable facts" section.
+- **Pydantic models** in `app/models/models.py` are load-bearing — treat them like a schema. Add fields, do not rename.
+
+---
+
+## 5. Testing
+
+The codebase has historically had no automated tests. We are adding them incrementally; see `tests/` and [`scripts/check_invariants.py`](scripts/check_invariants.py). **Every new PR should add at least one test for the change it introduces.** If the change is literally untestable, say so in the PR description.
+
+Minimum bar:
+
+- Unit test for any pure function you add or change.
+- Smoke test update (`scripts/smoke_test.py`) if you add a public URL or endpoint.
+
+---
+
+## 6. Reporting a bug or requesting a feature
+
+- **Bug**: use [`docs/templates/BUG.md`](docs/templates/BUG.md) or the GitHub "Bug" issue form.
+- **Feature**: use [`docs/templates/FEATURE.md`](docs/templates/FEATURE.md) or the "Feature" issue form.
+
+Templates are agent-optimized: future AI contributors will read the filled-out template as their primary source of truth for the task.
+
+---
+
+## 7. Getting help
+
+- Open an issue with as much of the relevant template filled out as you can.
+- Operator questions (prod, credentials, GCP): see [`docs/PRODUCTION_ENVIRONMENT.md`](docs/PRODUCTION_ENVIRONMENT.md) §7.
+- Accessibility questions: see [`docs/PROJECT_OVERVIEW.md`](docs/PROJECT_OVERVIEW.md) § "ADA / WCAG implementation".

--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -1,0 +1,473 @@
+# AGENT_CONTEXT — Student-Accessible-Powerpoint
+
+> **Purpose:** dense, structured context for AI coding agents. Ingest this file first. Pair with [`PROJECT_OVERVIEW.md`](./PROJECT_OVERVIEW.md) for narrative framing.
+>
+> **Last verified against:** `main` @ `1a31150` (Apache 2.0 license commit). Branch facts verified against `origin/*` refs.
+>
+> **Framework files** (added after this doc was written — check them before making changes):
+> [`../AGENTS.md`](../AGENTS.md) · [`guardrails/INVARIANTS.md`](guardrails/INVARIANTS.md) · [`guardrails/CHANGE_CHECKLIST.md`](guardrails/CHANGE_CHECKLIST.md) · [`ops/SOP_DEPLOY.md`](ops/SOP_DEPLOY.md) · [`templates/`](templates/) · [`../scripts/`](../scripts/).
+
+---
+
+## 0. TL;DR for agents
+
+- Product: Streamlit tool that adds WCAG/ADA-compliant alt text and speaker notes to `.pptx` decks, using Gemini vision + ChromaDB RAG.
+- Stack: Python 3.10/3.11, Streamlit, python-pptx, Pillow, pytesseract, FastAPI, ChromaDB, Google `google-generativeai` (gemini-2.0-flash-lite), pydantic v2, ImageMagick (external binary).
+- Three processes: Streamlit web (8501), FastAPI Chroma wrapper (8001), ChromaDB server (8000). The web app **never** imports `chromadb` directly — only HTTP.
+- Primary accessibility write: `shape._element._nvXxPr.cNvPr.attrib["descr"] = alt_text` (native OOXML). Fallback: `shape.alternative_text = alt_text`.
+- Entry point: `app/ppt_notes.py::main` (Streamlit). Orchestrator for the 4-stage UI (`upload` → `describe_images` → `final_processing` → `download`).
+- Quick dev start: `python start_app.py` (choose option 3).
+- Most feature-rich branch: `Aggrement` (consent wall, DOCX support, perf fixes, modular `pptx.py`/`word.py`, change log in `CATCH_UP.md`).
+- Experimental TS port: `nextjs-impl` (Next.js 16 + React 19, incomplete; Python kept in `backups/python-legacy/`).
+
+---
+
+## 1. Repository map (branch `main`)
+
+```
+/
+├── app/
+│   ├── ppt_notes.py              # Streamlit app; orchestrates pipeline
+│   ├── chroma-api/
+│   │   ├── app.py                # FastAPI wrapper for ChromaDB (port 8001)
+│   │   └── .env.example
+│   ├── models/
+│   │   ├── __init__.py           # empty
+│   │   └── models.py             # Pydantic v2 data models
+│   └── pptx_rag_quizzer/
+│       ├── __init__.py           # empty
+│       ├── utils.py              # parse_powerpoint(), OCR stub, format convert
+│       ├── rag_core.py           # Gemini + ChromaHTTPClient + RAGCore
+│       └── image.py              # Image class: 4-stage description pipeline
+├── docs/
+│   ├── PROJECT_OVERVIEW.md       # human narrative
+│   └── AGENT_CONTEXT.md          # this file
+├── start_app.py                  # dev launcher (Chroma API + Streamlit)
+├── requirements.txt              # full server + app dependencies
+├── requirements-app.txt          # app-only (no Chroma/FastAPI server)
+├── RAG_INTEGRATION_README.md
+├── LICENSE                       # Apache 2.0
+├── .env.example                  # GOOGLE_API_KEY only
+├── .gitattributes
+└── .gitignore                    # ignores .env, *.pptx, /venv, /chroma-db, *.pyc
+```
+
+**Python package root:** `app/`. Modules import as `pptx_rag_quizzer.*` and `models.*`. Streamlit must be launched with `streamlit run app/ppt_notes.py` from repo root so that `app/` is on the import path.
+
+---
+
+## 2. Data model (`app/models/models.py`)
+
+```python
+class Type(Enum):
+    image = "image"
+    text  = "text"
+
+class SlideItem(BaseModel):
+    id: str
+    slide_number: int
+    content: str                  # for Image: the generated description; starts as "none"
+    type: Type
+    order_number: int             # position within the slide's reading order
+
+class Image(SlideItem):
+    image_bytes: bytes            # raw (or PNG-normalized) image blob
+    extension: str
+    def metadata(self) -> dict    # used for Chroma metadata
+
+class Text(SlideItem):
+    def metadata(self) -> dict
+
+class Slide(BaseModel):
+    id: str
+    slide_number: int
+    items: List[Union[Image, Text]]
+
+class Presentation(BaseModel):
+    id: str
+    name: str
+    slides: List[Slide]
+
+class RAG_quizzer(BaseModel):     # currently unused, kept for parity with RAG-quizzer sibling project
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    id: str; name: str; presentation: Presentation; collection_id: str
+```
+
+**Critical invariant:** `order_number` is the *only* join key between a parsed `Image`/`Text` item and a `python-pptx` `shape`. `parse_powerpoint` increments `order_number` for BOTH text and image shapes, and `update_images_with_alt_text` (in the `Aggrement` branch's `pptx.py` — see §7) must mirror that exact sequence or alt text lands on the wrong shape.
+
+**On the `Aggrement` branch**, `Image` adds:
+```python
+@field_serializer('image_bytes')
+def serialize_image_bytes(self, value: bytes, _info) -> str:
+    return base64.b64encode(value).decode('utf-8')
+```
+…and additional `WordDocument` / `WordSection` / `WordText` / `WordImage` models for DOCX support.
+
+---
+
+## 3. Process topology
+
+```
+Streamlit (web, 8501) ──HTTP──▶ chroma-api (FastAPI, 8001) ──HTTPClient──▶ chromadb (8000, persistent)
+         │
+         └─HTTPS──▶ generativelanguage.googleapis.com  (Gemini)
+```
+
+- `web` never imports `chromadb`. See `rag_core.ChromaHTTPClient`.
+- `chroma-api` is a **thin** REST wrapper (`app/chroma-api/app.py`). Endpoints:
+  - `GET  /health`
+  - `GET  /collections` (list)
+  - `POST /collections` (create, body: `{name, metadata}`)
+  - `DELETE /collections/{name}`
+  - `GET  /collections/{name}/exists`
+  - `POST /collections/{name}/add` (body: `{documents, metadatas, ids}`)
+  - `POST /collections/{name}/query` (body: `{query_texts, n_results, include}`)
+  - `POST /collections/{name}/get` (body: `{include}`)
+- `make_json_serializable()` converts numpy arrays returned by Chroma into plain lists so FastAPI can serialize them.
+
+### Environment variables (authoritative list)
+
+| Var | Consumer | Default | Notes |
+|---|---|---|---|
+| `GOOGLE_API_KEY` | web (`rag_core.get_llm_model`, `ppt_notes.ExtractText_LLM`) | **required** | Gemini auth |
+| `CHROMA_API_URL` | web (`RAGCore.__init__`) | `http://localhost:8001` | Points web → FastAPI wrapper |
+| `CHROMA_SERVER_HOST` | chroma-api | `localhost` | Where FastAPI finds ChromaDB |
+| `CHROMA_SERVER_HTTP_PORT` | chroma-api | `8000` | ChromaDB port |
+| `API_HOST` / `API_PORT` | chroma-api | `0.0.0.0` / `8001` | FastAPI bind |
+| `ACME_EMAIL` | caddy (Prod-v1) | — | Let's Encrypt contact |
+
+---
+
+## 4. Primary control flow (`main` branch, `app/ppt_notes.py`)
+
+Streamlit `session_state.processing_stage` state machine:
+
+```
+upload ──▶ describe_images ──▶ final_processing ──▶ download
+   │                                                    │
+   └──── Quick Generate & Download (skip review) ───────┘
+```
+
+### `upload` stage
+1. `uploaded_file.read()` → `file_bytes`.
+2. `parse_powerpoint_file(file_bytes, name)` → `PresentationModel` (text + image blobs, `content='none'` for images).
+3. `RAGCore().create_collection(presentation_model)` → `collection_id` (initial collection: TEXT ONLY; images skipped while `content == 'none'` or `__DELETED__`).
+4. Store everything in `st.session_state`; jump to `describe_images`.
+
+**Quick-generate path** bypasses human review: iterates all image items, calls `ImageProcessor.describe_image` for each, strips the `"Description: "` prefix, then rebuilds the collection and jumps to `final_processing`'s equivalent.
+
+### `describe_images` stage
+- Images paged in batches of `batch_size=5`.
+- `batch_ready` = all images in batch have non-empty, non-`'none'`/`'null'` content.
+- If not ready: call `ImageProcessor.describe_image()` for each un-described image (this is where the 4-stage RAG pipeline fires).
+- If ready: render `st.image` + `st.text_area` for edit; user navigates `Previous/Next/Finish`.
+
+### `final_processing` stage
+1. `rag_core.remove_collection(old_collection_id)`.
+2. `rag_core.create_collection(presentation_model)` → **enhanced** collection (now includes image descriptions as documents).
+3. Write PPTX bytes to `temp_{filename}`.
+4. `process_powerpoint_with_rag_enhanced(temp_path, output_path, ...)` — see §5.
+5. `os.remove(temp_path)`; jump to `download`.
+
+### `download` stage
+- `st.download_button` serves `output_path` bytes with MIME `application/vnd.openxmlformats-officedocument.presentationml.presentation`.
+- Reset clears session state and deletes `output_path`.
+
+---
+
+## 5. Accessibility writer — `process_powerpoint_with_rag_enhanced`
+
+Defined in `app/ppt_notes.py`. Opens the PPTX with `python-pptx`, iterates slides and shapes, and writes three things:
+
+### 5.1 Alt text (for every `MSO_SHAPE_TYPE.PICTURE`)
+- Find matching description in `presentation_model` by comparing `shape.image.blob` to `item.image_bytes` (byte-equality). If not found or description is empty/`'none'`, use the fallback `"Image content - detailed description not available"`.
+- Write primary path:
+  ```python
+  shape._element._nvXxPr.cNvPr.attrib["descr"] = alt_text
+  ```
+- Write fallback path:
+  ```python
+  shape.alternative_text = alt_text
+  ```
+- Alt text is the full AI description; slide-deck-wide cap via `create_accessible_alt_text` (125-char guideline) is *defined but not currently invoked* on this path — the pipeline writes the full description directly.
+
+### 5.2 Chart / Table alt text
+- `MSO_SHAPE_TYPE.CHART` → `shape.alternative_text = f"Chart on slide {N} - {slide_title}"`
+- `MSO_SHAPE_TYPE.TABLE` → `shape.alternative_text = f"Table on slide {N} - {slide_title}"`
+
+### 5.3 Slide notes
+- Collect per-shape snippets into `notes_texts`.
+- If a `collection_id` is present, call `rag_core.get_context_from_slide_number(slide_index+1, collection_id)` and feed those docs into `generate_enhanced_notes_with_context` → `rag_core.prompt_gemini(...)` → enhanced notes.
+- Assign:
+  ```python
+  notes_slide = slide.notes_slide                # auto-creates if missing
+  notes_slide.notes_text_frame.text = "\n".join(notes_texts)
+  ```
+
+### 5.4 Persistence
+- `prs.save(output_path)` where `output_path = f"accessible_{file_name}"`.
+
+---
+
+## 6. Parser — `parse_powerpoint` (`app/pptx_rag_quizzer/utils.py`)
+
+```python
+def parse_powerpoint(file_object, file_name) -> Presentation:
+    prs = pptx_lib(file_object)
+    for slide_idx, slide in enumerate(prs.slides):
+        order_number = 0
+        # 1. Speaker notes (if any) as first Text item (order 0)
+        # 2. Sort shapes by (top, left) for reading order
+        for shape in sorted(slide.shapes, key=lambda x: (x.top or 0, x.left or 0)):
+            if shape.has_text_frame and shape.text_frame.text:
+                # append Text(content=..., order_number=order_number); order_number += 1
+            elif shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
+                # append Image(image_bytes=shape.image.blob, extension=shape.image.ext,
+                #              content='none', order_number=order_number); order_number += 1
+```
+
+Current `main` does **not** recurse into groups, diagrams, charts, or background fills — those are Aggrement-branch improvements (§7).
+
+`ExtractText_OCR(img_bytes)` is currently stubbed; the real Tesseract call is commented out and the function returns `"<THIS OCR TEXT IS IN DEVELOPMENT AND SHOULD BE DISREGARDED>"`. OCR is effectively disabled on `main`.
+
+---
+
+## 7. RAG image description — `app/pptx_rag_quizzer/image.py`
+
+Class `Image` (careful: same name as `models.models.Image` — import as `ImageProcessor` in callers).
+
+```python
+class Image:
+    def __init__(self, rag_core: RAGCore):
+        self.rag_core = rag_core
+        self.chat_history = []       # rolling, max 10
+        self.context_cache = {}      # cache_key -> {description, timestamp}
+        self.lambda_index = {}
+        self.cache_ttl = 3600
+```
+
+### 4-stage `describe_image(image_bytes, image_format, slide_number, collection_id, use_chat=True)`
+1. **OCR** — `ocr_image()` → `ExtractText_OCR()` (currently a stub, see §6).
+2. **Enhanced description** — `get_enhanced_description()`:
+   - Build prompt with `<ocr_text>`, `<slide_context>` (from `rag_core.get_context_from_slide_number`), and optional `<chat_history>`.
+   - `rag_core.prompt_gemini_with_image(prompt, image_bytes, image_format, max_output_tokens=200)`.
+   - Expected output prefix: `"Description: "`.
+3. **Lambda-Index context retrieval** — `get_context_with_lambda_index()`:
+   - `_build_lambda_query()` constructs a text query from description + top-10 key terms (stop-words filtered, len > 3).
+   - `rag_core.query_collection(...)` with `n_results=3`.
+   - `_rank_context_with_lambda()` scores each retrieved doc with `_calculate_lambda_score()`:
+     - `+0.1` per overlapping term.
+     - `+0.3` for image-type metadata, `+0.1` for slide-number metadata.
+     - Length-normalized, capped at 1.0, threshold `> 0.3` for inclusion.
+4. **Final description** — `get_final_description_with_chat()`:
+   - Gemini refines the enhanced description using context + chat history. 1–3 sentences, prefixed `"Description: "`.
+
+Response may be JSON (`{output: {Description: ...}}` or `{Description: ...}`); the code unwraps both.
+
+**Caching:** `cache_key = f"{md5(image_bytes)}_{slide_number}_{collection_id}"`, 1-hour TTL.
+
+**Chat-history:** up to 10 most-recent "Enhanced description: …" / "Final description: …" entries, used to stabilize vocabulary across slides.
+
+---
+
+## 8. `RAGCore` — `app/pptx_rag_quizzer/rag_core.py`
+
+```python
+class RAGCore:
+    def __init__(self, chroma_api_url=None):
+        self.llm_model = get_llm_model()                 # cached gemini-2.0-flash-lite
+        self.chroma_api = get_chroma_http_client_instance(...)
+
+    def create_collection(self, data: Presentation) -> str       # returns f"ppt_collection_{uuid8}"
+    def remove_collection(self, collection_id: str)              # returns dict (already .json()'d)
+    def query_collection(self, query_text, collection_id, n_results=1) -> dict
+    def get_random_slide_context(self, collection_id) -> dict
+    def get_random_slide_with_image(self, collection_id) -> dict|None
+    def get_context_from_slide_number(self, slide_number, collection_id) -> dict
+    def prompt_gemini(self, prompt, max_output_tokens=200) -> str
+    def prompt_gemini_with_image(self, prompt, image_bytes, image_format='png', max_output_tokens=200) -> str
+```
+
+### Collection layout
+- **One Chroma document per slide**. Each document is `" ".join(all text and image-description strings for that slide)`.
+- **Metadata per document** includes per-item fields `item_{n}_type`, `item_{n}_slide_number`, `item_{n}_order_number`, and for images `item_{n}_image_extension`, `item_{n}_has_image`, `item_{n}_image_size`. Plus top-level `slide_number` and `slide_id`.
+- Image items with `content == "__DELETED__"` are skipped at collection build time.
+
+### Gemini call conventions
+- `prompt_gemini_with_image` normalizes every image through PIL:
+  - `P` mode with `"transparency"` → convert to `RGBA`.
+  - `RGBA`/`LA` → paste onto white RGB background.
+  - Re-encode as PNG in memory.
+- Retries: `max_retries=3`, `delay=1s`. On `"Resource has been exhausted"` — sleeps `quota_refill_delay=60s`.
+
+### `ChromaHTTPClient` — note that its methods return `response.json()` (already-parsed dicts). Do not call `.json()` on `RAGCore.remove_collection(...)` return values (this was a historical bug — see `Aggrement`'s `CATCH_UP.md`).
+
+---
+
+## 9. Branches — exhaustive map
+
+### `main` (current; Apache 2.0)
+- HEAD: `1a31150 Include Apache License 2.0`.
+- State described throughout §§1–8.
+
+### `RAG-integration-branch`
+- Oldest. Single `Dockerfile`, `docker-compose.yml`, `DEPLOYMENT.md`.
+- Python 3.10 slim base, runs `streamlit run new-app/ppt_notes.py` (note: path is `new-app/`, not `app/` — the layout differs).
+- Relevant only for historical deployment references.
+
+### `Prod-v1`
+- Multi-service deployment scaffolding:
+  - `Dockerfile.api` — FastAPI wrapper container (python:3.11-slim + build-essential).
+  - `Dockerfile.web` — Streamlit container (python:3.11-slim + tesseract-ocr + libjpeg62-turbo-dev + zlib1g-dev + curl).
+  - `docker-compose.yml` — four services: `chroma`, `chroma-api`, `web`, `caddy` on an implicit shared network. `chroma` persists to `./chroma-db:/chroma/chroma`.
+  - `Caddyfile` — proxies `access.brockportsigai.org` → `web:8501`, ACME TLS via `{$ACME_EMAIL}`.
+- Same app code as `main` at commit `e6fcd8f`.
+
+### `Aggrement` — most feature-rich
+HEAD `ee8606d`. Key additions:
+
+- **IRB consent wall** (`app/ppt_notes.py`, stage `consent`):
+  - Four radio options (agree / agree+email / no / under-18).
+  - Under-18 → `processing_stage = 'blocked'`, `st.stop()`.
+  - Agreed-with-email → appended to `consent_responses.csv` via `save_consent_email(email, choice)` (creates CSV with header `timestamp_utc,email,choice`).
+- **AI-content warning banner** rendered at top of page.
+- **Module split inside `app/pptx_rag_quizzer/`:**
+  - `utils.py` — only `ExtractText_OCR`, `clean_text`, `clean_text_with_llm`, `convert_image_to_png_or_jpg` (uses subprocess + `magick`/`convert`; returns `(None, None)` for failed WMF/EMF).
+  - `pptx.py` — `parse_powerpoint` (recursive for groups/diagrams/charts/background), `generate_accessible_notes`, `rebuild_presentation_with_accessible_features` with inner `update_images_with_alt_text`. **Entry point for writing accessibility:** `rebuild_presentation_with_accessible_features(presentation_model, powerpoint_file_bytes_io)`.
+  - `word.py` — `parse_word_document`, `rebuild_word_document_with_accessible_features`. Uses `python-docx`; walks paragraphs, nested tables, headings (`_is_heading` checks `style.name.lower().startswith("heading")`). Images resolved by `a:blip/@r:embed` → `document.part.related_parts`. Alt text written to `wp:docPr/@descr`.
+- **Extended models** (§2): `WordDocument`/`WordSection`/`WordText`/`WordImage`, `base64` serializer on `Image.image_bytes`.
+- **Performance:**
+  - `rebuild_presentation_with_accessible_features` creates `rag_core = RAGCore()` once and passes it down (~70% speedup per `CATCH_UP.md`).
+  - `generate_accessible_notes` uses `max_output_tokens=400`, strips conversational preambles.
+- **Robustness:**
+  - `parse_powerpoint` recursion covers `MSO_SHAPE_TYPE.GROUP`, `DIAGRAM`, `CHART`, and background fills.
+  - Order-number tracking fixed so text and image shapes both increment the index used for image-shape matching.
+  - WMF/EMF: `(None, None)` return short-circuits image addition.
+- **Streamlit config** — `app/.streamlit/config.toml`:
+  ```toml
+  [server]
+  maxUploadSize = 500
+  maxMessageSize = 500
+  port = 8501
+  enableCORS = false
+  enableXsrfProtection = false
+  baseUrlPath = "accessibility"
+  ```
+- **`CATCH_UP.md`** — authoritative chronological change log (DOCX pipeline, WMF fix, perf optimizations, order-tracking bug, etc.). **Read this first when working on the Aggrement branch.**
+- Additional dependencies on this branch: `python-docx>=1.1.0`.
+
+### `nextjs-impl` — experimental TS/React port
+- `package.json`: `next@16.2.3`, `react@19.2.4`, `framer-motion@12.38.0`, `tailwindcss@4`, `adm-zip@0.5.17`, `xml2js@0.6.2`, `axios@1.15.0`.
+- Structure:
+  - `src/app/page.tsx` — client component, stages `upload`/`analyzing`/`review`/`download`.
+  - `src/app/api/process/route.ts` — Next.js Route Handler that parses PPTX via `PptxProcessor` and returns slide metadata.
+  - `src/lib/pptx-utils.ts` — `PptxProcessor` reads `ppt/slides/slide*.xml` from the zip and extracts `a:t` text nodes and image rels directly. **Does not yet implement rebuild/write-back.**
+  - `src/lib/gemini.ts` — `GeminiService` POSTs to `v1beta/models/gemini-2.0-flash:generateContent`.
+  - `src/lib/chroma.ts` — TypeScript mirror of the FastAPI client (`createCollection`, `addDocuments`, `createFromPresentation`).
+  - `backups/python-legacy/` — full copy of the Python app.
+  - `AGENTS.md` warns: *"This is NOT the Next.js you know — APIs, conventions, file structure may differ from your training data. Read `node_modules/next/dist/docs/` before writing code."*
+- **Maturity:** early prototype. The API route returns `{success, presentation: {slides: [{number, title, imageCount}]}}` and does not yet set alt text on the file or serve a rebuilt PPTX.
+
+---
+
+## 10. Critical invariants / foot-guns
+
+1. **Order-number matching is fragile.** `parse_powerpoint` must increment `order_number` on every shape that `update_images_with_alt_text` also increments on, and vice versa. Adding new shape types to one without the other will misalign every alt-text write for the rest of the slide. (See `CATCH_UP.md` 2024-12-19 "Order Number Tracking Fix".)
+2. **Never call `.json()` on `RAGCore.remove_collection(...)` return.** It's already a dict (the inner HTTP client decoded it). Same for the other wrapper methods.
+3. **Collection names** are `ppt_collection_{uuid4[:8].lower()}`. ChromaDB has naming rules — do not change the scheme without verifying.
+4. **`_nvXxPr` is python-pptx private API.** If python-pptx is upgraded, test `shape._element._nvXxPr.cNvPr.attrib["descr"]` — the fallback `shape.alternative_text = alt_text` is the officially supported path.
+5. **WMF/EMF images require ImageMagick** (`magick` or `convert` on `$PATH`). On `main`, Wand was previously used and has been removed; on `Aggrement`, `convert_image_to_png_or_jpg` gracefully returns `(None, None)` when ImageMagick is absent and the image is skipped. Do not reintroduce a hard dependency on Wand.
+6. **PIL palette-with-transparency** images must be converted `P → RGBA → composite on white → RGB` in that order, or Gemini will fail or PIL will emit `UserWarning`. The correct code is in `rag_core.prompt_gemini_with_image`.
+7. **OCR is a stub on `main`.** `ExtractText_OCR` returns a placeholder string. The `pytesseract` call is commented out. Do not assume OCR text is meaningful unless you re-enable it.
+8. **Gemini quota** errors trigger 60-second sleeps. Long runs can stall — batch size of 5 is a guardrail.
+9. **Session state keys** used by Streamlit (do not rename silently): `processing_stage`, `presentation_model`, `rag_core`, `image_processor`, `collection_id`, `current_batch`, `batch_size`, `output_path`, `uploaded_file_name`, `file_bytes`. On `Aggrement`: also `consent_completed`, `consent_choice`, `consent_email`, `new_presentation_model`.
+10. **Streamlit rerun semantics**: every `st.rerun()` re-enters `main()`; the stage machine is driven entirely by `st.session_state.processing_stage`. Don't introduce blocking loops outside of `st.spinner` contexts.
+11. **`requirements.txt` vs `requirements-app.txt`.** The app-only file omits `chromadb`, `fastapi`, `uvicorn`, `numpy`; use it for the web container. The full file is for the `chroma-api` container.
+12. **`.env` is gitignored; `.env.example` has only `GOOGLE_API_KEY`** — the Chroma env vars live in `app/chroma-api/.env.example`.
+
+---
+
+## 11. Accessibility specification (authoritative for agents)
+
+Target: **WCAG 2.1 Level AA**, per ADA Title II rule (28 CFR Part 35, 2024 amendment).
+
+| WCAG SC | Level | How this project fulfills it | Module |
+|---|---|---|---|
+| 1.1.1 Non-text Content | A | Gemini-generated alt text written to native `cNvPr/@descr` for every extracted image, diagram, chart image, and background fill. | `ppt_notes.process_powerpoint_with_rag_enhanced` + `pptx_rag_quizzer/image.Image` |
+| 1.3.1 Info & Relationships | A | Reading order preserved by `(top, left)` sort; slide notes regenerated in Markdown with headings + bullets. | `pptx_rag_quizzer/utils.parse_powerpoint` + `generate_enhanced_notes_with_context` |
+| 1.3.2 Meaningful Sequence | A | Same top-to-bottom / left-to-right extraction order; `order_number` preserved end-to-end. | `utils.parse_powerpoint` |
+| 1.4.5 Images of Text | AA | OCR text (when enabled) passes through Gemini so that raster-baked text is echoed in the description. | `pptx_rag_quizzer/image.Image.ocr_image` (stubbed on main) |
+| 2.4.2 Page Titled | A | Slide title extracted and included in notes as `## Slide N: {Title}`. | `ppt_notes.process_powerpoint_with_rag_enhanced` |
+| 2.4.6 Headings and Labels | AA | Notes are generated with explicit markdown headings; chart/table alt text includes slide title context. | Notes generator prompt in `ppt_notes.generate_enhanced_notes_with_context` |
+| 3.1.5 Reading Level | AAA (partial) | Prompt asks for "clear, concise explanations"; AI-content warning prompts human verification. | Aggrement `pptx.generate_accessible_notes` prompt |
+| 4.1.2 Name, Role, Value | A | All alt text written to standard OOXML (`cNvPr/@descr`) — no custom metadata. | python-pptx shape mutation |
+
+**Known gaps / not yet implemented:**
+- 1.4.3 Contrast (Minimum) — not inspected.
+- 1.2.x Media-related SCs (captions, audio description) — not generated.
+- 2.4.4 Link Purpose (In Context) — hyperlinks not rewritten.
+- On-slide accessibility tab-order (the order a screen reader walks *visually* on a slide) is not actively reordered; only reading-order of *extraction* is stable.
+
+When adding features, agents should:
+- Preserve native OOXML attributes (never invent custom namespaces).
+- Always populate both the primary path (`cNvPr/@descr`) and the fallback (`shape.alternative_text`).
+- Keep generated text under 125 characters *for alt text* when possible (current writer passes the full description — if you add trimming, use `create_accessible_alt_text` which already exists in `ppt_notes.py` as an unused helper).
+
+---
+
+## 12. Test & verification notes
+
+- **No formal test suite exists** in any branch. `app/test.py` is referenced in `Aggrement`'s `CATCH_UP.md` but not present in the tracked tree.
+- Quick smoke-test flow: launch via `python start_app.py` (choose 3) → upload `sample.pptx` → use "Quick Generate & Download" → open output in PowerPoint → Review → Check Accessibility.
+- Screen-reader end-to-end: open output in PowerPoint → run the built-in Accessibility Checker; run NVDA in Presenter View to verify alt text is announced.
+- ChromaDB debug: `curl http://localhost:8001/health`, `curl http://localhost:8001/collections`.
+
+---
+
+## 13. Common extension recipes
+
+- **Switch LLM provider.** Replace `get_llm_model()` in `rag_core.py` and adapt `prompt_gemini*`. Leave the `RAGCore` public surface unchanged.
+- **Add a new accessibility transform** (e.g., heading style enforcement). Insert a new step in `process_powerpoint_with_rag_enhanced` (main) or `rebuild_presentation_with_accessible_features` (Aggrement). Always increment `order_number` consistently if you consume shapes.
+- **Persist descriptions across sessions.** Add a `descriptions` table keyed on `md5(image_bytes)` (same hash already used for caching in `image.Image`).
+- **Add a new file format.** Mirror the Aggrement `word.py` module: `parse_X_document` → `{Model}Document` → `rebuild_X_document_with_accessible_features`. Ensure an order-number join key exists.
+- **Move off ChromaDB.** Only `RAGCore` and `ChromaHTTPClient` need replacing; the `chroma-api` service can be rebuilt against any vector DB. The web app's contract with the wrapper is six HTTP endpoints (§3).
+
+---
+
+## 14. Quick reference: file → purpose
+
+| File | Purpose | Size |
+|---|---|---|
+| `app/ppt_notes.py` | Streamlit app & accessibility writer (`main`) | 27 KB |
+| `app/pptx_rag_quizzer/utils.py` | PPTX parser + OCR stub + format convert | ~4 KB on `main`; ~5 KB on `Aggrement` |
+| `app/pptx_rag_quizzer/rag_core.py` | LLM + Chroma HTTP client | 18 KB |
+| `app/pptx_rag_quizzer/image.py` | 4-stage RAG image description | 23 KB |
+| `app/pptx_rag_quizzer/pptx.py` | (Aggrement only) rebuild pipeline | 23 KB |
+| `app/pptx_rag_quizzer/word.py` | (Aggrement only) DOCX support | 12 KB |
+| `app/models/models.py` | Pydantic models | 1–3 KB |
+| `app/chroma-api/app.py` | FastAPI wrapper | 6 KB |
+| `start_app.py` | dev launcher | 3.7 KB |
+| `requirements.txt` / `requirements-app.txt` | pins | <1 KB each |
+| `RAG_INTEGRATION_README.md` | narrative feature doc | 8 KB |
+| `docs/PROJECT_OVERVIEW.md` | human-readable overview | — |
+| `docs/AGENT_CONTEXT.md` | **this file** | — |
+
+---
+
+## 15. Stable fact list (agents: trust these)
+
+- License: **Apache 2.0** (`LICENSE`, added in commit `1a31150`).
+- Organization: **SUNY Brockport ACM Student Chapter**.
+- LLM model ID: `gemini-2.0-flash-lite` (both `ppt_notes.py` and `rag_core.py`).
+- PPTX library: `python-pptx`. DOCX library: `python-docx` (Aggrement only).
+- Vector DB: ChromaDB, accessed only via `http://…:8001` (FastAPI wrapper). Web process does NOT import `chromadb`.
+- Default batch size: 5 images.
+- Default notes token budget: `main` 500, `Aggrement` 400.
+- Default RAG retrieval: `n_results=3`, Lambda score threshold `0.3`.
+- Default image cache TTL: 3600 s.
+- Default chat-history window: 10 messages.
+- Native alt-text attribute written: `a:cNvPr@descr` on each `pic` element.
+
+---
+
+*When in doubt: consult `Aggrement/CATCH_UP.md` for the deepest history of what was tried, what broke, and why the code looks the way it does.*

--- a/docs/PRODUCTION_ENVIRONMENT.md
+++ b/docs/PRODUCTION_ENVIRONMENT.md
@@ -1,0 +1,536 @@
+# Production Environment
+
+Authoritative map of the **live** Student-Accessible-Powerpoint deployment on Google Cloud Platform.
+
+> **Scope:** GCP project `brockport-acm-sigai-project`. Accessed via `gcloud compute ssh` as `davelonski12@gmail.com`. Of the 6 running VMs, 3 were SSH-accessible; the remaining 3 return `compute.instances.setMetadata` permission denied and are not covered here.
+>
+> **Companion files:** [`PROJECT_OVERVIEW.md`](./PROJECT_OVERVIEW.md) (human narrative) · [`AGENT_CONTEXT.md`](./AGENT_CONTEXT.md) (agent reference).
+>
+> **Last verified:** Apr 22, 2026.
+
+---
+
+## 1. TL;DR
+
+- **Production URL:** `https://access.brockportsigai.org/accessibility`
+- **Production VM:** `instance-20250905-023343-pub` (zone `us-central1-c`, `e2-medium`, Debian 12 Bookworm, external IP `34.42.255.126`).
+- **Deployed branch:** `Aggrement` — *not* `main` and *not* the Docker-based `Prod-v1` layout documented in the repo.
+- **Deployment style:** **Bare-metal Python** on systemd, **not Docker Compose**. The `Prod-v1` branch's `docker-compose.yml` + Caddy stack is not used in production.
+- **Process manager:** 3 systemd units under user `mattarama443` (Chroma daemon, Chroma REST wrapper, Streamlit app).
+- **Reverse proxy / TLS:** nginx + Let's Encrypt (certbot), *not* Caddy.
+- **Repo on prod:** `/home/mattarama443/Student-Accessible-Powerpoint` — currently has **uncommitted local modifications** to `app/ppt_notes.py` and `start_app.py` plus untracked `.streamlit/` and `start_scripts/` directories (architectural drift, see §6).
+- **Second app on the same VM:** a separate project (`davidlonski/RAG-Dev`, branch `Prod-v1`) runs alongside at `/rag-application` on port 8502. It is **not** part of this repo.
+- **Older deployment still running:** `instance-20250610-144049` (us-east1-c) carries an older install under user `davelonski12` with the same nginx `server_name access.brockportsigai.org` — but DNS does not point there anymore. It is effectively orphaned prod.
+- **Non-project CI/CD box:** `instance-20251114-154547-main-dev` runs Jenkins (port 8080) + a Next.js dev server for an unrelated project (`edually-backend`). No Student-Accessible-Powerpoint pipeline lives there.
+
+---
+
+## 2. Instance Inventory
+
+From `gcloud compute instances list` (project `brockport-acm-sigai-project`):
+
+| Instance | Zone | Type | External IP | SSH | Role |
+|---|---|---|---|---|---|
+| `instance-20250905-023343-pub` | us-central1-c | e2-medium | 34.42.255.126 | ✅ | **Production** (Student-Accessible-Powerpoint + RAG-Dev) |
+| `instance-20250610-144049` | us-east1-c | e2-standard-2 | 35.196.195.118 | ✅ | Older prod install (orphan, still running) |
+| `instance-20251114-154547-main-dev` | us-central1-a | e2-medium | 35.192.148.196 | ✅ | Jenkins CI + unrelated Next.js dev |
+| `instance-20250628-145549` | us-central1-f | e2-medium | 35.238.7.137 | ❌ denied | unknown |
+| `instance-20250704-210400-brockportsigai` | us-east1-c | e2-medium | 34.75.70.146 | ❌ denied | unknown (name suggests Brockport-branded deployment) |
+| `instance-20250628-145549-yub` | northamerica-northeast1-c | e2-medium | 35.203.22.246 | ❌ denied | unknown (static IP `static-ip-for-yub`) |
+
+Static IPs reserved in the project:
+
+| Reservation | Address | Region | Status |
+|---|---|---|---|
+| `arraywall-ip-adress` | 34.47.4.212 | northamerica-northeast1 | RESERVED (unused) |
+| `static-ip-for-yub` | 35.203.22.246 | northamerica-northeast1 | IN_USE by `-yub` |
+
+Firewall (VPC `default`):
+
+| Rule | Direction | Allow | Notes |
+|---|---|---|---|
+| `default-allow-ssh` | INGRESS | tcp:22 | |
+| `default-allow-http` | INGRESS | tcp:80 | prod nginx |
+| `default-allow-https` | INGRESS | tcp:443 | prod nginx (TLS) |
+| `allow-8501` | INGRESS | tcp:8501 | **Streamlit exposed directly to the internet** — bypasses nginx |
+| `allow-8001` | INGRESS | tcp:8001 | **Chroma REST API exposed directly to the internet** |
+| `allow-port-1000` | INGRESS | tcp:1000 | unused |
+| `default-allow-internal` | INGRESS | all TCP/UDP | intra-VPC |
+| `default-allow-icmp` | INGRESS | icmp | |
+| `default-allow-rdp` | INGRESS | tcp:3389 | unused on Linux boxes |
+
+Instance `-pub` carries the network tags `http-server`, `https-server`, `lb-health-check`.
+
+---
+
+## 3. Production Topology (`instance-20250905-023343-pub`)
+
+### 3.1 Request path
+
+```
+Browser ──HTTPS──▶ nginx :443  (access.brockportsigai.org)
+                      │
+                      ├─ /                → static /var/www/streamlit-home/index.html  (landing)
+                      ├─ /accessibility   → 127.0.0.1:8501  (Streamlit → Student-Accessible-Powerpoint)
+                      └─ /rag-application → 127.0.0.1:8502  (Streamlit → RAG-Dev, SEPARATE PROJECT)
+
+Streamlit :8501 (student-access-ppt.service, user mattarama443)
+       │
+       └─HTTP──▶ 127.0.0.1:8001  chroma-api (FastAPI wrapper, chromadbapi.service)
+                          │
+                          └─HTTP──▶ [::1]:8000  chromadb server (chromadbd.service, chroma run)
+                                              └─ data: /home/mattarama443/Student-Accessible-Powerpoint/chroma/  (~15 MB)
+
+Streamlit :8502 (ad-hoc nohup process, user mattarama443, cwd=/home/mattarama443/RAG-Dev)
+       │
+       └─HTTP──▶ 127.0.0.1:8003  RAG-Dev chroma-api
+                          │
+                          └─HTTP──▶ 127.0.0.1:8010  RAG-Dev chroma (port 8010)
+```
+
+### 3.2 nginx config — `/etc/nginx/sites-enabled/streamlit-https`
+
+```nginx
+server {
+    if ($host = access.brockportsigai.org) {
+        return 301 https://$host$request_uri;
+    }
+    listen 80;
+    server_name access.brockportsigai.org;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name access.brockportsigai.org;
+    ssl_certificate     /etc/letsencrypt/live/access.brockportsigai.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/access.brockportsigai.org/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    client_max_body_size 500M;           # matches Streamlit maxUploadSize
+
+    root /var/www/streamlit-home;
+    index index.html;
+
+    location / { try_files $uri $uri/ =404; }
+
+    location /accessibility {
+        proxy_pass http://127.0.0.1:8501;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";     # required for Streamlit WebSocket
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For  $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /rag-application {
+        proxy_pass http://127.0.0.1:8502;
+        # (identical upgrade / forwarded headers)
+    }
+}
+```
+
+Certbot is wired via `certbot.timer` (next run ~13 h out, last run ~8 h ago). Certs renew automatically.
+
+### 3.3 systemd units
+
+All three services run as user **`mattarama443`** with `WorkingDirectory=/home/mattarama443/Student-Accessible-Powerpoint`. Configured for restart on failure.
+
+| Unit | Script | Command |
+|---|---|---|
+| `chromadbd.service` | `start_scripts/chromadbd.sh` | `venv/bin/chroma run` (binds `[::1]:8000`) |
+| `chromadbapi.service` | `start_scripts/chromadbapi.sh` | `python app/chroma-api/app.py` (binds `0.0.0.0:8001`) |
+| `student-access-ppt.service` | `start_scripts/streamlit.sh` | `streamlit run app/ppt_notes.py` (binds `0.0.0.0:8501`) |
+
+Unit file for reference (Streamlit):
+
+```ini
+[Unit]
+Description=Streamlit Frontend for Student Accessible Powerpoint Services
+After=network.target
+
+[Service]
+Type=simple
+User=mattarama443
+WorkingDirectory=/home/mattarama443/Student-Accessible-Powerpoint
+ExecStart=/bin/bash /home/mattarama443/Student-Accessible-Powerpoint/start_scripts/streamlit.sh
+Restart=on-failure
+RestartSec=5
+KillMode=process
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Start scripts, verbatim:
+
+```bash
+# start_scripts/chromadbd.sh
+cd /home/mattarama443/Student-Accessible-Powerpoint
+source venv/bin/activate
+venv/bin/chroma run
+
+# start_scripts/chromadbapi.sh
+cd /home/mattarama443/Student-Accessibility-Powerpoint     # ⚠ TYPO: directory does not exist
+source venv/bin/activate
+python app/chroma-api/app.py
+
+# start_scripts/streamlit.sh
+cd /home/mattarama443/Student-Accessible-Powerpoint
+source venv/bin/activate
+streamlit run app/ppt_notes.py
+```
+
+**⚠ Footgun.** The `chromadbapi.sh` `cd` fails silently (`Accessibility` vs `Accessible`). The FastAPI wrapper still runs because systemd's `WorkingDirectory=` directive anchors the process before bash runs; `python app/chroma-api/app.py` is resolved against the systemd working directory, not the failed `cd` target. If anyone removes or changes the `WorkingDirectory` line, the service will silently break. **Fix the script.**
+
+Ports on pub observed via `ss -tlnp`:
+
+| Port | Process | Bind |
+|---|---|---|
+| 22 | sshd | 0.0.0.0 |
+| 80 | nginx (3 workers) | 0.0.0.0 |
+| 443 | nginx | 0.0.0.0 |
+| 8000 | chromadbd (`chroma run`) | `[::1]` (localhost-only) |
+| 8001 | chromadbapi (`python app/chroma-api/app.py`) | 0.0.0.0 — **also exposed via firewall `allow-8001`** |
+| 8010 | RAG-Dev chroma | 127.0.0.1 |
+| 8003 | RAG-Dev chroma-api | 0.0.0.0 |
+| 8501 | student-access-ppt (Streamlit) | 0.0.0.0 — **also exposed via firewall `allow-8501`** |
+| 8502 | RAG-Dev Streamlit | 0.0.0.0 |
+| 25 | exim4 (localhost only) | 127.0.0.1 |
+| 20201 / 20202 | Google Cloud Ops Agent (metrics + logs) | — |
+
+### 3.4 Code layout on prod
+
+```
+/home/mattarama443/Student-Accessible-Powerpoint/   (branch: Aggrement, remote: SUNY-Brockport-ACM-Student-Chapter/...)
+├── .env                     # GOOGLE_API_KEY=<redacted>  (403 bytes)
+├── .streamlit/              # untracked — only config.toml (baseUrlPath=accessibility)
+├── app/                     # Aggrement branch layout (pptx.py, word.py, image.py, etc.)
+│   ├── ppt_notes.py         # Streamlit entry (LOCALLY MODIFIED — drift from Aggrement HEAD)
+│   ├── chroma-api/app.py    # FastAPI wrapper
+│   ├── pptx_rag_quizzer/    # {utils, pptx, word, image, rag_core}.py
+│   └── models/models.py
+├── chroma/                  # ChromaDB persistent data (~15 MB, untracked)
+├── consent_responses.csv    # IRB consent log — 6 rows so far (first entry 2026-04-16)
+├── start_scripts/           # untracked — the three systemd start scripts
+├── venv/                    # Python 3.11.2 virtualenv
+├── requirements.txt / requirements-app.txt
+├── start_app.py             # LOCALLY MODIFIED
+└── RAG_INTEGRATION_README.md
+```
+
+Git state (`sudo -u mattarama443 git status -s`):
+```
+ M app/ppt_notes.py
+ M start_app.py
+?? .streamlit/
+?? app/app.out
+?? app/ppt_notes.py.bak
+?? chroma/
+?? start_scripts/
+```
+Branch `Aggrement` at commit `6a8175a` (one commit behind `origin/Aggrement`'s HEAD `ee8606d` observed in the repo analysis — so prod is slightly stale even from its own branch). The modifications to `app/ppt_notes.py` and `start_app.py` are **not in any upstream branch**: there is untracked production-only configuration living on the VM.
+
+Virtualenv key pins (Python 3.11.2):
+```
+streamlit, python-pptx, Pillow, google-generativeai==0.8.6, chromadb==1.5.7, fastapi==0.135.3,
+pydantic, requests, pytesseract
+```
+
+### 3.5 Secrets
+
+- `/home/mattarama443/Student-Accessible-Powerpoint/.env` holds the live `GOOGLE_API_KEY`. Not referenced by any external secret manager; lives on disk only.
+- `/opt/vault/` exists on `main-dev` but is not wired into this production VM. There is no HashiCorp Vault, GCP Secret Manager, or other secret injection on prod.
+- TLS cert + key live in `/etc/letsencrypt/live/access.brockportsigai.org/`, rotated by the `certbot.timer`.
+
+### 3.6 User accounts on `pub`
+
+`/home/` contents: `davel`, `davelonski12`, `mattarama443`, `yubrajkhatri977`, `zgsdwhwd`. The running application stack is wholly owned by `mattarama443`. Other homes exist for operators with SSH access.
+
+### 3.7 Second app sharing the VM (`RAG-Dev`)
+
+`/home/mattarama443/RAG-Dev/` — repository `https://github.com/davidlonski/RAG-Dev.git`, branch `Prod-v1`. Launched **without** systemd (ad-hoc `nohup` via `sudo -u mattarama443`). Listens on 8502 behind `location /rag-application` in nginx. Uses its own virtualenv, its own ChromaDB instance (ports 8010 + 8003), its own `chroma-data/` directory. **Not part of this repo.** Mentioned here only because any ops work on pub touches it.
+
+---
+
+## 4. Older production install — `instance-20250610-144049`
+
+Still running, but superseded. It has the same `server_name access.brockportsigai.org` in its nginx config, yet DNS now resolves to `pub` (34.42.255.126), so this box is effectively dark for public traffic — although port 8501 is still listed in the firewall, making it reachable directly by IP.
+
+| Fact | Value |
+|---|---|
+| Zone | us-east1-c |
+| External IP | 35.196.195.118 |
+| App user | `davelonski12` |
+| App dir | `/home/davelonski12/Student-Accessible-Powerpoint` (~2.7 GB) |
+| Process manager | **None** — raw `nohup` (e.g. `nohup venv/bin/python3 venv/bin/streamlit run app/ppt_notes.py --server.port 8501 --server.headless true > /tmp/streamlit.log 2>&1 &`) |
+| Services visible | only `nginx.service`; chroma + streamlit are foreground `nohup` processes |
+| nginx | HTTP-only, proxies `/` → `127.0.0.1:8501`; has `/.well-known/acme-challenge/` alias but no 443 listener |
+| Chroma | `chroma run --path chroma-db` on `[::1]:8000` (same-venv pattern, same as pub) |
+| chroma-api | `python app.py` on `0.0.0.0:8001` |
+
+This box is the predecessor of pub. It confirms the historical deployment pattern (systemd-less, one-user, same dir layout). **Recommended action:** either shut it down or confirm retention is intentional — see §7.
+
+---
+
+## 5. Jenkins + Next.js dev box — `instance-20251114-154547-main-dev`
+
+Not part of this product, included for completeness since it was SSH-accessible.
+
+- Debian 12, up 158 days.
+- **Jenkins** at `http://35.192.148.196:8080` (service `jenkins.service`, running since 2026-02-16). No jobs or workspaces configured (`/var/lib/jenkins/workspace/` does not exist). Jenkins is installed but unused for this project.
+- **Next.js dev server** on port 3000: `next-server (v16.0.3)` run by user `legonate` from `/home/legonate/edually-backend/` — a separate project unrelated to Student-Accessible-Powerpoint.
+- `/opt/vault/` present but no systemd unit, not actively serving.
+
+There is **no CI/CD pipeline** for Student-Accessible-Powerpoint anywhere in the project. Deployment is manual.
+
+---
+
+## 6. Codebase ↔ Live — Deltas
+
+The repository's `README`, `Prod-v1` branch, and `DEPLOYMENT.md` document one deployment model; production uses another. Agents working on deployments must understand these differences.
+
+| Aspect | Repo says | Live actually is |
+|---|---|---|
+| Packaging | `Prod-v1` branch: Docker Compose (chroma + chroma-api + web + caddy) | Bare-metal systemd units; no Docker on the VM (`docker` command not installed) |
+| Reverse proxy | Caddy (ACME via Let's Encrypt) | nginx + certbot |
+| Config toml | `app/.streamlit/config.toml` with `baseUrlPath=accessibility` | Repo's `.streamlit/` is **untracked on prod** — the deployed config was created on the VM, not pulled from the branch (it matches the Aggrement-branch config anyway) |
+| Start scripts | `start_app.py` (interactive Python) | Three shell scripts in `start_scripts/`, invoked by systemd; `start_app.py` is locally modified and unused |
+| Deployed branch | — | `Aggrement` (consent-wall branch), not `main`, not `Prod-v1` |
+| Process isolation | Per-service container | Same Linux user (`mattarama443`), same virtualenv |
+| Persistent Chroma volume | `./chroma-db:/chroma/chroma` container mount | `/home/mattarama443/Student-Accessible-Powerpoint/chroma/` directory in the repo tree |
+| Secrets | `GOOGLE_API_KEY` via compose env | `.env` file in the repo directory on the VM |
+| Path-based hosting | `baseUrlPath = accessibility` + Caddy reverse | `baseUrlPath = accessibility` + nginx reverse |
+| Second Streamlit app (`/rag-application`) | **Not in repo** | Present — different project (`RAG-Dev`) running under the same user |
+| Load balancer | not in repo | Instance tag `lb-health-check` suggests one was considered; no LB resources currently attach |
+| CI/CD | not in repo | None; Jenkins exists on a separate box but has no jobs |
+
+**Observed drift on the VM:**
+- Uncommitted edits to `app/ppt_notes.py` and `start_app.py`.
+- `chromadbapi.sh` contains a typo (`Accessibility` ≠ `Accessible`) that is masked by the systemd `WorkingDirectory`.
+- Prod is at commit `6a8175a` of `Aggrement`; upstream is at `ee8606d`. Not pulled.
+
+---
+
+## 7. Operator playbook
+
+### 7.1 How to SSH into prod
+```bash
+gcloud compute ssh instance-20250905-023343-pub --zone=us-central1-c
+```
+
+### 7.2 How to view logs
+```bash
+# Streamlit app
+sudo journalctl -u student-access-ppt -f
+
+# Chroma REST wrapper
+sudo journalctl -u chromadbapi -f
+
+# Chroma DB
+sudo journalctl -u chromadbd -f
+
+# nginx
+sudo tail -f /var/log/nginx/error.log /var/log/nginx/access.log
+```
+
+### 7.3 Restart the app
+```bash
+sudo systemctl restart student-access-ppt     # Streamlit
+sudo systemctl restart chromadbapi            # FastAPI wrapper
+sudo systemctl restart chromadbd              # ChromaDB (nuking this drops the vector collection cache for in-flight jobs)
+```
+Start order on boot: `chromadbd` → `chromadbapi` → `student-access-ppt`. The `After=` clauses in the unit files are weak (`After=network.target` only), so if Chroma is slow to come up on reboot the API may race it; the API has `Restart=on-failure`, so it eventually recovers.
+
+### 7.4 Deploy a code change (current manual process)
+```bash
+gcloud compute ssh instance-20250905-023343-pub --zone=us-central1-c
+sudo -u mattarama443 -H bash -lc '
+  cd /home/mattarama443/Student-Accessible-Powerpoint
+  git stash                                   # preserve the production-only edits
+  git pull origin Aggrement
+  source venv/bin/activate
+  pip install -r requirements.txt             # if deps changed
+  git stash pop                               # reapply local edits
+'
+sudo systemctl restart chromadbapi student-access-ppt
+```
+
+> Before pulling, capture the diff of local modifications — some of them are production-only (e.g. server-specific Streamlit flags). Plan to upstream them instead of stashing forever.
+
+### 7.5 Rotate the Gemini API key
+```bash
+sudo -u mattarama443 nano /home/mattarama443/Student-Accessible-Powerpoint/.env
+sudo systemctl restart student-access-ppt
+```
+
+### 7.6 Renew TLS (automatic, but manual if ever needed)
+```bash
+sudo certbot renew --nginx
+sudo systemctl reload nginx
+```
+
+### 7.7 Inspect consent records
+```bash
+sudo -u mattarama443 cat /home/mattarama443/Student-Accessible-Powerpoint/consent_responses.csv
+```
+CSV columns: `timestamp_utc,email,choice`. At last check, 6 rows (5 responses + header).
+
+### 7.8 Scale / capacity notes
+- `e2-medium` = 2 vCPU, 4 GB RAM. Gemini calls are the bottleneck, not CPU. Large decks (>30 slides) are fine.
+- ChromaDB store at ~15 MB — no pressure.
+- `client_max_body_size 500M` in nginx matches Streamlit's `maxUploadSize = 500` in the repo config.
+- Single instance, no autoscaling, no LB. If it dies, `instance-20250610-144049` can be repurposed by repointing DNS, but it has no TLS listener and no systemd units — reviving it is a manual job.
+
+---
+
+## 8. Known issues / recommended cleanups
+
+1. **Typo in `start_scripts/chromadbapi.sh`** — `cd .../Student-Accessibility-Powerpoint` should be `.../Student-Accessible-Powerpoint`. Currently masked by `WorkingDirectory=`. Fix.
+2. **Production drift vs git** — `app/ppt_notes.py` and `start_app.py` carry uncommitted local changes. Capture them in a branch or stop editing on the VM.
+3. **`start_scripts/` is not in git** on any branch. Add them to the repo (possibly alongside the existing `start_app.py`).
+4. **Firewall rules `allow-8001` and `allow-8501` expose the internal services directly to the public internet**, bypassing nginx and TLS. The Streamlit UI is reachable as `http://34.42.255.126:8501` and the FastAPI wrapper as `http://34.42.255.126:8001`. Unless this is deliberate for debugging, tighten to `lb-health-check` tag or delete.
+5. **Two instances advertise the same nginx `server_name` (`access.brockportsigai.org`).** `pub` serves it via HTTPS; `instance-20250610-144049` still answers on HTTP. Retire the old instance or remove its nginx config to avoid confusion.
+6. **No monitoring/alerting pipeline** beyond the Google Cloud Ops Agent. No uptime check configured (that would have caught the old-instance orphaning).
+7. **Single point of failure.** No LB, no autoscaler, no redundancy. An outage on `pub` takes the product down.
+8. **Secrets on disk.** `.env` with the Gemini key is plaintext in the home directory. Consider GCP Secret Manager.
+9. **No CI/CD** for this project. Jenkins on `main-dev` is idle. Deployments are manual SSH + git pull.
+10. **`chroma` data directory is inside the checked-out repo** (`./chroma/`). A careless `git clean -fdx` would wipe all vector data. Move it outside the repo and point `chroma run --path …` at the new location.
+
+---
+
+## 9. Agent-oriented quick reference (dense)
+
+> Read this block before touching production.
+
+```yaml
+gcp_project: brockport-acm-sigai-project
+gcloud_account: davelonski12@gmail.com
+default_zone: us-east1-d     # cli default, NOT where prod lives
+prod:
+  instance: instance-20250905-023343-pub
+  zone: us-central1-c
+  external_ip: 34.42.255.126
+  dns: access.brockportsigai.org -> 34.42.255.126
+  os: debian-12-bookworm
+  arch: amd64
+  machine_type: e2-medium
+  network_tags: [http-server, https-server, lb-health-check]
+  app_user: mattarama443
+  app_dir: /home/mattarama443/Student-Accessible-Powerpoint
+  deployed_branch: Aggrement
+  deployed_commit: 6a8175a       # one commit behind origin/Aggrement HEAD ee8606d (as observed)
+  secondary_app:
+    repo: https://github.com/davidlonski/RAG-Dev.git
+    branch: Prod-v1
+    path: /home/mattarama443/RAG-Dev
+    process: nohup (no systemd)
+    nginx_path: /rag-application
+    chroma_port: 8010
+    chroma_api_port: 8003
+    streamlit_port: 8502
+  services_systemd:
+    chromadbd.service:
+      user: mattarama443
+      exec: /bin/bash /home/mattarama443/Student-Accessible-Powerpoint/start_scripts/chromadbd.sh
+      listens: "[::1]:8000"
+      cmd: "venv/bin/chroma run"
+    chromadbapi.service:
+      exec: /bin/bash /home/mattarama443/Student-Accessible-Powerpoint/start_scripts/chromadbapi.sh
+      listens: "0.0.0.0:8001"
+      cmd: "python app/chroma-api/app.py"
+      bug: "script cd's to nonexistent 'Student-Accessibility-Powerpoint'; saved by systemd WorkingDirectory"
+    student-access-ppt.service:
+      exec: /bin/bash /home/mattarama443/Student-Accessible-Powerpoint/start_scripts/streamlit.sh
+      listens: "0.0.0.0:8501"
+      cmd: "streamlit run app/ppt_notes.py"
+  nginx:
+    config: /etc/nginx/sites-enabled/streamlit-https
+    tls_cert: /etc/letsencrypt/live/access.brockportsigai.org/
+    renewer: certbot.timer (daily ~22:00 UTC)
+    client_max_body_size: 500M
+    routes:
+      /:                  "static /var/www/streamlit-home/index.html"
+      /accessibility:     "127.0.0.1:8501  (Streamlit, Upgrade headers for WS)"
+      /rag-application:   "127.0.0.1:8502"
+  runtime:
+    python: 3.11.2
+    venv: /home/mattarama443/Student-Accessible-Powerpoint/venv
+    key_pkgs: {chromadb: 1.5.7, fastapi: 0.135.3, google-generativeai: 0.8.6}
+  secrets:
+    env_file: /home/mattarama443/Student-Accessible-Powerpoint/.env
+    contains: [GOOGLE_API_KEY]
+    storage: plain file on disk; no Vault/Secret Manager
+  persistence:
+    chroma_data: /home/mattarama443/Student-Accessible-Powerpoint/chroma   # ~15 MB
+    consent_log: /home/mattarama443/Student-Accessible-Powerpoint/consent_responses.csv
+  firewall:
+    public: [22, 80, 443, 8001, 8501]
+    internal_only: [8000, 8002/unused, 8010 (RAG-Dev chroma)]
+  drift_from_repo:
+    - "Bare-metal systemd instead of Prod-v1 docker-compose"
+    - "nginx + certbot instead of Caddy"
+    - "Uncommitted edits to app/ppt_notes.py, start_app.py"
+    - "start_scripts/ and .streamlit/ not tracked in any branch"
+    - "Prod is 1 commit behind origin/Aggrement"
+
+old_prod:
+  instance: instance-20250610-144049
+  zone: us-east1-c
+  external_ip: 35.196.195.118
+  status: "orphan — still running, no DNS, http-only nginx"
+  app_user: davelonski12
+  app_dir: /home/davelonski12/Student-Accessible-Powerpoint
+  process_mgr: nohup (no systemd)
+  nginx: "server_name access.brockportsigai.org → 127.0.0.1:8501 (port 80 only)"
+
+ci_dev_box:
+  instance: instance-20251114-154547-main-dev
+  zone: us-central1-a
+  external_ip: 35.192.148.196
+  relevant_to_this_project: false
+  services: [jenkins (:8080, no jobs configured), next-server (legonate/edually-backend, :3000), vault installed but inactive]
+
+inaccessible_instances:
+  - name: instance-20250628-145549
+    zone: us-central1-f
+    deny_reason: "compute.instances.setMetadata permission"
+  - name: instance-20250704-210400-brockportsigai
+    zone: us-east1-c
+    deny_reason: "compute.instances.setMetadata permission"
+    note: "name suggests Brockport-branded deployment; warrants follow-up with an account holding permissions"
+  - name: instance-20250628-145549-yub
+    zone: northamerica-northeast1-c
+    deny_reason: "compute.instances.setMetadata permission"
+    external_ip_reserved_as: static-ip-for-yub
+
+static_ips:
+  arraywall-ip-adress: {ip: 34.47.4.212, region: northamerica-northeast1, status: RESERVED}
+  static-ip-for-yub:   {ip: 35.203.22.246, region: northamerica-northeast1, status: IN_USE}
+
+deploy_procedure:
+  - "gcloud compute ssh instance-20250905-023343-pub --zone=us-central1-c"
+  - "sudo -u mattarama443 git -C /home/mattarama443/Student-Accessible-Powerpoint pull origin Aggrement"
+  - "(optional) source venv/bin/activate && pip install -r requirements.txt"
+  - "sudo systemctl restart chromadbapi student-access-ppt"
+
+incident_playbook:
+  app_hung:
+    - "sudo systemctl restart student-access-ppt"
+    - "sudo journalctl -u student-access-ppt -n 200"
+  chroma_hung:
+    - "sudo systemctl restart chromadbd chromadbapi"
+    - "verify: curl -sf http://localhost:8001/health"
+  tls_expired:
+    - "sudo certbot renew --nginx && sudo systemctl reload nginx"
+  disk_full:
+    - "check /home/mattarama443/Student-Accessible-Powerpoint/chroma and /tmp/*.log"
+  gemini_quota:
+    - "app already sleeps 60s on 'Resource has been exhausted'; no action unless sustained"
+```
+
+---
+
+*Documentation generated from live reconnaissance on Apr 22, 2026. Inaccessible instances should be revisited when permissions are granted — in particular `instance-20250704-210400-brockportsigai`, whose name strongly suggests it hosts a Brockport-branded deployment.*

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -1,0 +1,257 @@
+# Student-Accessible-Powerpoint — Project Overview
+
+A human-readable guide to the project's purpose, architecture, branch-by-branch evolution, and ADA Title II / WCAG accessibility implementation.
+
+> **Companion files:**
+> - [`AGENT_CONTEXT.md`](./AGENT_CONTEXT.md) — dense technical reference for AI agents.
+> - [`PRODUCTION_ENVIRONMENT.md`](./PRODUCTION_ENVIRONMENT.md) — live GCP deployment map.
+> - [`README.md`](./README.md) — index of all docs.
+> - [`../CONTRIBUTING.md`](../CONTRIBUTING.md) — how to set up, change, and ship the code.
+
+---
+
+## 1. What This Project Does
+
+Student-Accessible-Powerpoint (originally piloted at the SUNY Brockport ACM Student Chapter) is a tool that transforms standard `.pptx` presentations into **ADA Title II / WCAG 2.1 AA compliant** documents by:
+
+1. **Extracting** every text run, image, chart, table, and background fill from a deck.
+2. **Indexing** the extracted content into a **ChromaDB** vector collection so each image can be described with awareness of its surrounding slide and of the entire presentation.
+3. **Generating alt text** for every image using **Google Gemini** (multi-stage RAG pipeline: OCR → enhanced description → Lambda-Index context retrieval → final description).
+4. **Generating comprehensive speaker notes** for each slide that summarize the slide in Markdown and describe all visual content — so a student using a screen reader receives the same information as a sighted student.
+5. **Writing the results back** into native PowerPoint XML fields (`cNvPr/@descr` for alt text, `notesSlide` for notes) so the output is a standard `.pptx` that Office, Google Slides, and screen readers all understand without any custom tooling.
+
+The end user uploads a PPTX in a Streamlit UI, (optionally) reviews AI-generated descriptions, and downloads an accessibility-enhanced file.
+
+---
+
+## 2. Architecture at a Glance
+
+```
+┌─────────────────────────┐      ┌──────────────────────────┐      ┌──────────────────────┐
+│  Streamlit UI           │──────▶│  Accessibility Pipeline  │──────▶│ Google Gemini API    │
+│  (app/ppt_notes.py)     │      │  (pptx_rag_quizzer/*)    │      │ gemini-2.0-flash-lite│
+│  - upload / batch review│      │  - parse_powerpoint      │      └──────────────────────┘
+│  - download             │      │  - ImageProcessor (RAG)  │                  ▲
+└─────────────────────────┘      │  - rebuild_presentation  │                  │
+           │                     └──────────────────────────┘                  │ image + prompt
+           │                                │                                  │
+           │                                ▼                                  │
+           │                     ┌──────────────────────────┐                  │
+           │                     │ ChromaDB HTTP Wrapper    │◀─────────────────┘
+           │                     │ (FastAPI, port 8001)     │
+           │                     │  app/chroma-api/app.py   │
+           │                     └──────────────────────────┘
+           │                                │
+           │                                ▼
+           │                     ┌──────────────────────────┐
+           │                     │ ChromaDB Server (8000)   │
+           │                     │ persistent volume        │
+           │                     └──────────────────────────┘
+```
+
+### Three processes, one deployment
+- **`web`** — Streamlit app (`app/ppt_notes.py`), port 8501.
+- **`chroma-api`** — Thin FastAPI wrapper over ChromaDB, port 8001. It exists so the web app never talks to ChromaDB's native client directly, making the app deployable without the heavy `chromadb` Python dependency.
+- **`chroma`** — ChromaDB server, port 8000, persistent volume.
+
+The Caddy reverse proxy (production branches) terminates TLS in front of `web`.
+
+### Major modules
+
+| Module | Responsibility |
+|---|---|
+| `app/ppt_notes.py` | Streamlit UI; orchestrates the 4-stage user flow (upload → describe → final processing → download). |
+| `app/pptx_rag_quizzer/utils.py` | `parse_powerpoint()` — extracts text + images from a `.pptx`; `convert_image_to_png_or_jpg()` — normalizes exotic formats (WMF/EMF/SVG) via ImageMagick. |
+| `app/pptx_rag_quizzer/rag_core.py` | `RAGCore` — talks to Chroma via HTTP; `prompt_gemini()` and `prompt_gemini_with_image()` with quota/retry handling. |
+| `app/pptx_rag_quizzer/image.py` | `Image` processor — 4-stage RAG image-description pipeline with caching, Lambda-Index ranking, and chat-history continuity. |
+| `app/models/models.py` | Pydantic data models: `Presentation`, `Slide`, `SlideItem`, `Image`, `Text`. |
+| `app/chroma-api/app.py` | FastAPI service exposing REST endpoints for collections, documents, and queries. |
+| `start_app.py` | Developer helper that starts the ChromaDB API and Streamlit app together. |
+
+---
+
+## 3. Branch-by-Branch Evolution
+
+The repository's history reads as an incremental hardening of a single product. Each branch represents a milestone.
+
+### 🟢 `main` — current stable (Apache 2.0)
+- Core pipeline: parse → build RAG text collection → per-batch image description (Gemini) → rebuild collection with image descriptions → write alt text + generate RAG-enhanced notes → save output PPTX.
+- Two-path UI: full review workflow **or** `Quick Generate & Download (Skip Review)` for speed.
+- HTTP-only Chroma access (no native `chromadb` dependency on the web process).
+- `requirements-app.txt` introduced as a slimmer install target for the Streamlit process.
+- `2691d92` added native PPTX alt-text attribute (`cNvPr/@descr`) with a `alternative_text` fallback — this is the canonical commit for ADA-grade alt-text plumbing.
+- `898c490` added the `Quick Generate & Download` option.
+
+### 🟠 `RAG-integration-branch` — the original Dockerized release
+- First "production-ish" deployment, built on a single `Dockerfile` and a `docker-compose.yml` exposing port 8501.
+- `DEPLOYMENT.md` documents the Debian-bookworm VM setup (Docker CE + Docker Compose plugin).
+- This is the heritage branch — everything on `main` descends from it.
+
+### 🟣 `Prod-v1` — multi-service production deployment
+Adds:
+- **Split Dockerfiles**: `Dockerfile.api` (FastAPI Chroma wrapper) and `Dockerfile.web` (Streamlit with Tesseract + libjpeg).
+- **`docker-compose.yml` with four services**: `chroma`, `chroma-api`, `web`, `caddy`.
+- **Caddy reverse proxy** with ACME/Let's Encrypt for `access.brockportsigai.org`.
+- Introduces inter-container networking (`CHROMA_API_URL=http://chroma-api:8001`, `CHROMA_SERVER_HOST=chroma`).
+
+This is the blueprint for running the system on a cloud VM with TLS, persistent Chroma storage, and independent scaling of the three tiers.
+
+### 🟡 `Aggrement` — ADA/IRB consent gate + feature expansion (most feature-rich)
+The most ambitious branch. Adds:
+
+- **IRB/Research Consent Wall** (`c14117b`) — a mandatory Streamlit gate that collects informed-consent responses before the user can upload a file. This is required because the tool is used as an educational-research instrument at SUNY Brockport. Consent decisions (and email, when volunteered) are appended to a local `consent_responses.csv`.
+- **Under-18 block stage** — hard-stops the workflow for minors.
+- **AI-content warning** — Streamlit banner reminds the instructor that AI output may contain errors.
+- **Modular pipeline split** — `utils.py` is broken into:
+  - `utils.py` — OCR + image-format conversion only.
+  - `pptx.py` — `parse_powerpoint()` + `generate_accessible_notes()` + `rebuild_presentation_with_accessible_features()`.
+  - `word.py` — **new: DOCX parsing & alt-text rebuilder** (`parse_word_document`, `rebuild_word_document_with_accessible_features`). Word support uses `python-docx` and walks paragraphs, tables, and nested cells, applying alt text to `wp:docPr/@descr`.
+- **Expanded Pydantic models** — `WordDocument`, `WordSection`, `WordText`, `WordImage` alongside the original presentation models; `Image.image_bytes` is now base64-serialized via `@field_serializer` so the model is JSON-round-trippable.
+- **Major accessibility & performance improvements** (`6ba2cb8`):
+  - Reuse a single `RAGCore()` instance across all slides (~70 % speedup, per `CATCH_UP.md`).
+  - Token budget raised 200 → 400 for non-truncated notes.
+  - Post-processing strips AI "Okay, here are…" preambles.
+  - Native `cNvPr/@descr` alt-text path with `alternative_text` fallback.
+  - Recursive shape processing (groups, diagrams, charts, background fills).
+  - Order-number tracking fixed so text shapes also increment the index used to match images back to their parsed counterparts.
+  - Graceful WMF/EMF failure: `convert_image_to_png_or_jpg()` returns `(None, None)` and the pipeline skips the image instead of crashing.
+  - PIL palette-with-transparency warning fixed by explicit `P → RGBA → RGB on white background` conversion.
+- **Streamlit config** — `app/.streamlit/config.toml` sets `maxUploadSize = 500 MB` and a `baseUrlPath = "accessibility"` for path-based hosting behind Caddy.
+- **`CATCH_UP.md`** — detailed chronological change log of every fix/feature in the branch (the most thorough single document in the repo).
+
+### 🔵 `nextjs-impl` — experimental TS/React port
+- Full migration to **Next.js 16** + **React 19** + **TypeScript** + **Tailwind CSS 4**.
+- Uses `adm-zip` + `xml2js` to parse PPTX directly from the `ppt/slides/*.xml` entries (no `python-pptx`).
+- A `GeminiService` class calls `gemini-2.0-flash:generateContent` via `axios`.
+- A `ChromaService` class mirrors the Python HTTP client.
+- The Python implementation is preserved under `backups/python-legacy/` for reference.
+- Status: early — the `/api/process` route returns slide metadata only; the rebuild/write-back pathway is not yet ported.
+
+### Branch evolution, summarized
+
+| Milestone | Branch |
+|---|---|
+| First RAG-enhanced accessibility pipeline + Docker | `RAG-integration-branch` |
+| Alt-text & Options merged to main | `main` (PRs #1, #2) |
+| Multi-service Docker + Caddy TLS | `Prod-v1` |
+| IRB consent, DOCX support, perf + robustness, CATCH_UP log | `Aggrement` |
+| TypeScript / Next.js rewrite (experimental) | `nextjs-impl` |
+| Apache 2.0 license added | `main` (commit `1a31150`) |
+
+---
+
+## 4. ADA Title II / WCAG Compliance — How It's Implemented
+
+**ADA Title II** (updated 2024 regulations) requires state and local government entities — including public universities — to make digital content conform to **WCAG 2.1 Level AA** by April 2026/2027. This project targets the WCAG success criteria most commonly violated by slide decks.
+
+### 4.1 Non-text content (WCAG 1.1.1 — Level A)
+**Every image gets a real alt-text description, not a placeholder.**
+
+- Parsing: `parse_powerpoint()` extracts every image blob — regular pictures, diagrams, charts, grouped shapes (recursively), and background fills — and normalizes it to PNG/JPG via ImageMagick (`convert_image_to_png_or_jpg`). WMF/EMF failures are logged and skipped rather than crashing the whole deck.
+- Description generation (`pptx_rag_quizzer/image.py` — 4 stages):
+  1. **OCR** via Tesseract on any text baked into the image.
+  2. **Enhanced description** — Gemini receives the image + OCR text + the rest of the slide's text context, producing a 1–3 sentence visual-primary description.
+  3. **Lambda-Index context retrieval** — key terms from the enhanced description query Chroma across the whole presentation, then results are re-ranked by term overlap × image-metadata relevance.
+  4. **Final description** — Gemini refines the description using the retrieved cross-slide context and a rolling chat history so descriptions remain consistent across similar images in the deck.
+- Writing: `update_images_with_alt_text()` sets the native PPTX XML attribute:
+  ```python
+  shape._element._nvXxPr.cNvPr.attrib["descr"] = alt_text
+  ```
+  With `shape.alternative_text = alt_text` as a fallback. This is the attribute every major screen reader (JAWS, NVDA, VoiceOver, Narrator) reads, so descriptions survive export to PDF, Google Slides, and Keynote.
+
+### 4.2 Programmatically determined info & relationships (WCAG 1.3.1 — Level A)
+- **Speaker notes** (the `notesSlide` part of the PPTX) are regenerated for every slide with a Markdown-formatted summary that includes:
+  - Slide title (`## Slide N: …`)
+  - Key concepts as bullet points
+  - Visual-element descriptions (so a blind student reading the notes knows what was on screen)
+- Charts and tables receive their own descriptive alt text (`Chart on slide N — {title}`, `Table on slide N — {title}`).
+- Reading order is preserved by sorting shapes top-to-bottom, left-to-right (`sorted(shapes, key=lambda x: (x.top, x.left))`) before extraction.
+
+### 4.3 Language of parts & consistent voice (WCAG 3.1.x)
+- A rolling `chat_history` (max 10 entries) is passed into Gemini on each image so descriptions stay consistent across a 50-slide deck (e.g., the same diagram style is described with the same vocabulary each time).
+
+### 4.4 Robust, machine-readable output (WCAG 4.1.x)
+- All metadata is written into standard OOXML elements (`cNvPr/@descr`, `notesSlide`, `descr` on `wp:docPr` for DOCX on the `Aggrement` branch). No custom namespaces, no proprietary extensions.
+- `Aggrement/app/.streamlit/config.toml` raises `maxUploadSize` to 500 MB so long instructor decks are not silently truncated.
+
+### 4.5 Reasonable-use safeguards
+- The `Aggrement` branch adds an **AI-content warning banner** prompting the instructor to verify AI output before distribution — important because WCAG conformance requires *accurate* text alternatives, and an uncorrected hallucination could itself be a violation.
+- The 4-stage `describe_images` batch UI exists specifically so a human can review and edit every description before it is written to the file.
+- The IRB consent gate ensures the research-deployment context complies with human-subjects rules at SUNY Brockport.
+
+### 4.6 What the project does *not* yet cover (known gaps)
+- **Color contrast** (WCAG 1.4.3) is not inspected or corrected.
+- **Live captions / audio descriptions** are not generated for embedded media.
+- **Reading-order reordering** only affects extraction, not the on-slide tab order shown in the Accessibility Inspector.
+- **Hyperlink descriptive text** (WCAG 2.4.4) is not rewritten.
+
+These are reasonable roadmap items and are called out in the RAG README under "Future Enhancements".
+
+---
+
+## 5. Running the Project
+
+### Local development (on `main`)
+```bash
+pip install -r requirements.txt
+# .env must contain GOOGLE_API_KEY
+python start_app.py      # starts Chroma API + Streamlit together
+```
+
+### Production (on `Prod-v1`)
+```bash
+docker compose up --build -d     # starts chroma, chroma-api, web, caddy
+# Visit https://access.brockportsigai.org
+```
+
+### Research deployment with consent gate (on `Aggrement`)
+Same as `Prod-v1`, but the Streamlit app first requires the user to complete the consent radio-form; responses are appended to `consent_responses.csv` on the container volume.
+
+### Environment variables
+
+| Variable | Purpose | Default |
+|---|---|---|
+| `GOOGLE_API_KEY` | Gemini auth | **required** |
+| `CHROMA_API_URL` | URL to the FastAPI wrapper | `http://localhost:8001` |
+| `CHROMA_SERVER_HOST` | Where `chroma-api` finds the ChromaDB server | `localhost` |
+| `CHROMA_SERVER_HTTP_PORT` | ChromaDB port | `8000` |
+| `API_HOST` / `API_PORT` | FastAPI wrapper bind | `0.0.0.0` / `8001` |
+| `ACME_EMAIL` | Caddy TLS contact (Prod-v1) | — |
+
+---
+
+## 6. Repository Layout (current `main`)
+
+```
+Student-Accessible-Powerpoint/
+├── app/
+│   ├── ppt_notes.py                  # Streamlit UI & orchestrator
+│   ├── chroma-api/
+│   │   ├── app.py                    # FastAPI wrapper over ChromaDB
+│   │   └── .env.example
+│   ├── models/
+│   │   └── models.py                 # Pydantic models
+│   └── pptx_rag_quizzer/
+│       ├── utils.py                  # parse_powerpoint, OCR, image convert
+│       ├── rag_core.py               # Gemini + Chroma HTTP client
+│       └── image.py                  # 4-stage RAG image description
+├── docs/
+│   ├── PROJECT_OVERVIEW.md           # this file
+│   └── AGENT_CONTEXT.md              # rapid-ingestion AI-agent context
+├── start_app.py                      # dev launcher
+├── requirements.txt                  # full (web + api + chroma)
+├── requirements-app.txt              # Streamlit-only dependencies
+├── RAG_INTEGRATION_README.md         # narrative RAG feature doc
+├── LICENSE                           # Apache 2.0
+├── .env.example
+├── .gitattributes
+└── .gitignore
+```
+
+---
+
+## 7. Further Reading
+- [`../RAG_INTEGRATION_README.md`](../RAG_INTEGRATION_README.md) — the original feature-centric README for the RAG workflow.
+- [`./AGENT_CONTEXT.md`](./AGENT_CONTEXT.md) — the structured reference for AI coding agents.
+- Branch `Aggrement`'s `CATCH_UP.md` — a detailed chronological change log of every fix/optimization in the most advanced branch.
+- U.S. DOJ ADA Title II rule (2024), 28 CFR Part 35 — the legal basis for WCAG 2.1 AA conformance this project targets.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,61 @@
+# Documentation Index
+
+Start here.
+
+| File | Audience | Purpose |
+|---|---|---|
+| [`PROJECT_OVERVIEW.md`](PROJECT_OVERVIEW.md) | Humans | Narrative overview of the project, architecture, branch evolution, ADA/WCAG implementation. |
+| [`AGENT_CONTEXT.md`](AGENT_CONTEXT.md) | AI agents | Dense rapid-ingestion technical reference: data model, control flow, RAG pipeline, branch comparison, footguns. |
+| [`PRODUCTION_ENVIRONMENT.md`](PRODUCTION_ENVIRONMENT.md) | Ops | Live GCP deployment map, differences from the repo, operator playbook. |
+| [`../AGENTS.md`](../AGENTS.md) | AI agents | Top-level entry point and hard invariants. |
+| [`../CONTRIBUTING.md`](../CONTRIBUTING.md) | Humans | Developer onboarding, setup, change flow. |
+
+## `ops/` — Standard Operating Procedures
+
+| File | When to use |
+|---|---|
+| [`ops/SOP_DEPLOY.md`](ops/SOP_DEPLOY.md) | Shipping a change to production. |
+| [`ops/SOP_ROLLBACK.md`](ops/SOP_ROLLBACK.md) | Backing out a bad deploy. |
+| [`ops/SOP_INCIDENT.md`](ops/SOP_INCIDENT.md) | Prod is broken. |
+| [`ops/SOP_SECRETS.md`](ops/SOP_SECRETS.md) | Rotating or adding a secret. |
+| [`ops/DEPLOY_LOG.md`](ops/DEPLOY_LOG.md) | Append-only log of prod deploys. |
+| [`ops/INCIDENT_LOG.md`](ops/INCIDENT_LOG.md) | Append-only post-incident notes. |
+| [`ops/SECRET_ROTATION_LOG.md`](ops/SECRET_ROTATION_LOG.md) | Append-only rotation log. |
+
+## `guardrails/` — Architectural protection
+
+| File | Purpose |
+|---|---|
+| [`guardrails/INVARIANTS.md`](guardrails/INVARIANTS.md) | Hard invariants that must not be violated, with Check commands. |
+| [`guardrails/BRANCHING.md`](guardrails/BRANCHING.md) | Branch roles, cherry-pick flow, protected-branch rules. |
+| [`guardrails/CHANGE_CHECKLIST.md`](guardrails/CHANGE_CHECKLIST.md) | Pre-merge checklist to paste into every PR. |
+
+## `templates/` — Change request forms
+
+| File | Use when... |
+|---|---|
+| [`templates/FEATURE.md`](templates/FEATURE.md) | Proposing / building a new capability. |
+| [`templates/UPDATE.md`](templates/UPDATE.md) | Bumping a dependency or changing config. |
+| [`templates/BUG.md`](templates/BUG.md) | Reporting / fixing a defect. |
+| [`templates/REFACTOR.md`](templates/REFACTOR.md) | Structural change with no behavior change. |
+
+---
+
+## Where everything lives
+
+```
+repo/
+  AGENTS.md                 - agent entry point (invariants + routing)
+  CONTRIBUTING.md           - human onboarding
+  docs/
+    README.md               - this file
+    PROJECT_OVERVIEW.md     - human narrative
+    AGENT_CONTEXT.md        - agent-dense tech reference
+    PRODUCTION_ENVIRONMENT.md
+    ops/                    - SOPs + logs
+    guardrails/             - invariants, branching, checklist
+    templates/              - change request templates
+  scripts/                  - doctor, preflight, check_invariants, smoke_test
+  tests/                    - pytest suite (minimal)
+  .github/                  - PR & issue templates, CI workflow, CODEOWNERS
+```

--- a/docs/guardrails/BRANCHING.md
+++ b/docs/guardrails/BRANCHING.md
@@ -1,0 +1,94 @@
+# Branching Policy
+
+The repo has several long-lived branches that each mean something different. Cross-merging them blind has broken things. This file is the policy.
+
+---
+
+## 1. The branches
+
+| Branch | Role | Owns... |
+|---|---|---|
+| `main` | Canonical codebase. The "source of truth" for the project's design. | Core app, models, RAG core, Streamlit UI |
+| `Aggrement` | **What production runs.** Adds the IRB consent gate and modular split (`pptx.py` + `word.py`). | Consent wall, Word support |
+| `Prod-v1` | Dockerized deployment model. *Not actually deployed* — see [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) §6. | `docker-compose.yml`, Caddy config |
+| `nextjs-impl` | Experimental Next.js/React rewrite of the frontend. Not shipped. | `frontend/` Next.js app |
+| `RAG-integration-branch` | Legacy RAG prototype. Archive. | Historical reference only |
+
+---
+
+## 2. Where your change goes
+
+Decide before you branch.
+
+| Change type | Land on | Then forward to |
+|---|---|---|
+| Bug fix in core RAG, parsing, UI, models | `main` | Cherry-pick or merge into `Aggrement` for prod |
+| New feature in core pipeline | `main` | Cherry-pick into `Aggrement` after design review |
+| Consent-gate / IRB / research-only logic | `Aggrement` | Nowhere — stays on `Aggrement` |
+| Docker / Caddy / compose changes | `Prod-v1` | Nowhere — `Prod-v1` is currently dormant |
+| Next.js frontend experiments | `nextjs-impl` | Nowhere until the rewrite is the plan of record |
+
+**Never merge `Aggrement` → `main`** directly. It carries IRB-specific code that doesn't belong in the canonical branch. Use `git cherry-pick` for the core bits that do.
+
+**Never merge `Prod-v1` → `main`** directly. It carries deployment artifacts that don't belong in the app tree.
+
+---
+
+## 3. Branch naming for short-lived work
+
+```
+feat/<slug>        new capability
+fix/<slug>         bug fix
+chore/<slug>       tooling / docs / non-code
+refactor/<slug>    structural change, no behavior change
+deps/<slug>        dependency bump
+```
+
+Examples: `feat/word-consent-wall`, `fix/order-number-groups`, `refactor/move-chroma-outside-repo`.
+
+---
+
+## 4. The cherry-pick flow (main → Aggrement)
+
+When a fix on `main` needs to reach production:
+
+```bash
+git checkout Aggrement
+git pull
+git cherry-pick <sha-on-main>      # or --no-commit for a range
+# resolve any conflicts (the modular split in Aggrement often causes them)
+git push origin Aggrement
+```
+
+Then open a PR against `Aggrement` — even cherry-picks get a PR so the deploy log has a record. After merge, follow [`../ops/SOP_DEPLOY.md`](../ops/SOP_DEPLOY.md).
+
+---
+
+## 5. The migration decision (when do we collapse branches?)
+
+Long-term, having `main` ≠ production is a liability. Two acceptable end-states:
+
+- **Option A (recommended):** promote `Aggrement` as the default branch, demote `main` to archival. Rename and update all docs.
+- **Option B:** make `main` the source of truth, carry the consent gate via a feature flag. Retire `Aggrement`.
+
+Either migration is a `REFACTOR.md`, not a one-liner. Do not start it without buy-in from the course / research owner.
+
+---
+
+## 6. What the production VM sees
+
+Production runs `Aggrement`. The VM's `git status` historically shows uncommitted edits (see [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) §3.4). Agent contract: **you do not commit on the VM.** All commits happen via PR; the VM only runs `git pull`. If you see drift, capture it with [`../ops/SOP_DEPLOY.md`](../ops/SOP_DEPLOY.md) §1.
+
+---
+
+## 7. Protected-branch rules (to be configured)
+
+On GitHub, `main` and `Aggrement` should have:
+
+- Require PR before merging.
+- Require at least 1 approving review.
+- Require status checks (once CI exists): `preflight`, `tests`, `check_invariants`.
+- Disallow force-push.
+- Disallow deletion.
+
+These are not currently enforced at the repo level. Configure them.

--- a/docs/guardrails/CHANGE_CHECKLIST.md
+++ b/docs/guardrails/CHANGE_CHECKLIST.md
@@ -1,0 +1,64 @@
+# Change Checklist
+
+Before you mark a PR "ready for review", walk through this list. Paste it into the PR description and check items off. If an item is N/A, write "N/A — reason" instead of deleting the line.
+
+---
+
+## A. Intent
+
+- [ ] I picked the right template ([`FEATURE`](../templates/FEATURE.md) / [`UPDATE`](../templates/UPDATE.md) / [`BUG`](../templates/BUG.md) / [`REFACTOR`](../templates/REFACTOR.md)) and filled it out in the PR description.
+- [ ] I identified which branch this targets ([`BRANCHING.md`](BRANCHING.md)) and why.
+- [ ] If this is a behavior change, I noted the expected user-visible difference.
+
+## B. Invariants
+
+- [ ] I read [`INVARIANTS.md`](INVARIANTS.md) and confirmed none are violated.
+- [ ] If the change touches parsing, rebuild, or XML writing, I verified #1 (`order_number`) and #2 (`cNvPr/@descr`) still hold.
+- [ ] If the change touches Gemini calls, I preserved the 60 s rate-limit sleep (invariant #3).
+- [ ] If the change touches ChromaDB, access still goes through the FastAPI wrapper (invariant #4).
+- [ ] If the change touches images, PIL `P` / WMF / EMF normalization still happens before Gemini (invariant #5).
+- [ ] If the change touches the Aggrement branch, the consent gate still runs before upload (invariant #8).
+
+## C. Local validation
+
+- [ ] `python scripts/doctor.py` passes.
+- [ ] `python scripts/check_invariants.py` passes.
+- [ ] `python -m pytest -q` passes (or: N/A — no tests apply, with justification).
+- [ ] `python scripts/preflight.py` passes.
+- [ ] I ran the three-process stack locally and uploaded a `.pptx` end-to-end at least once.
+
+## D. Dependencies & config
+
+- [ ] If I added a Python dep: it's pinned in `requirements.txt` **and** `requirements-app.txt` (if the Streamlit UI uses it).
+- [ ] If I added an env var: it's listed (with a placeholder) in `.env.example` and documented in [`../AGENT_CONTEXT.md`](../AGENT_CONTEXT.md).
+- [ ] If I added a new port or public route: it's noted in [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) and in a `deploy` label on the PR.
+
+## E. Accessibility (non-negotiable)
+
+- [ ] My change does not reduce WCAG 2.1 AA conformance ([`../PROJECT_OVERVIEW.md`](../PROJECT_OVERVIEW.md) ADA section).
+- [ ] If my change affects alt-text generation, I spot-checked the output deck in PowerPoint's Accessibility Checker on at least one slide.
+- [ ] If my change affects reading order, groups, or tables, I verified with a screen reader (NVDA / VoiceOver) or documented why I couldn't.
+
+## F. Production safety
+
+- [ ] If this needs a deploy, I linked to [`../ops/SOP_DEPLOY.md`](../ops/SOP_DEPLOY.md) and identified a rollback SHA.
+- [ ] If this affects the Gemini model, secret format, or startup order, I flagged it with `breaking-change` on the PR.
+- [ ] I did **not** commit anything in `.env`, API keys, or generated `.pptx` files.
+- [ ] I did **not** modify `chroma/` or anything else that would be affected by `git clean -fdx` on prod.
+
+## G. Docs
+
+- [ ] If behavior changed, I updated [`../AGENT_CONTEXT.md`](../AGENT_CONTEXT.md) (agent-facing) and/or [`../PROJECT_OVERVIEW.md`](../PROJECT_OVERVIEW.md) (human-facing).
+- [ ] If an operational procedure changed, I updated the matching SOP under `docs/ops/`.
+- [ ] If I introduced a new guardrail, I added it to [`INVARIANTS.md`](INVARIANTS.md) with a `Check` command.
+
+## H. Tests
+
+- [ ] I added at least one test for the code I changed, OR explicitly stated why a test is impractical.
+- [ ] I updated `scripts/smoke_test.py` if I added or changed a public URL, endpoint, or health indicator.
+
+---
+
+## If any box is unchecked
+
+Either check it or replace it with `N/A — <reason>`. Unchecked boxes in an open PR = request-changes.

--- a/docs/guardrails/INVARIANTS.md
+++ b/docs/guardrails/INVARIANTS.md
@@ -33,7 +33,13 @@ python scripts/check_invariants.py --only order_number
 
 **Why.** Screen readers (NVDA, JAWS, VoiceOver) read `cNvPr/@descr`. `python-pptx`'s `alternative_text` property sometimes writes to a different location depending on shape type, and is silently ignored by some clients.
 
-**Where.** `app/ppt_notes.py :: process_powerpoint_with_rag_enhanced` → the XML patching block. Look for `cNvPr` and `descr`.
+**Where.** Varies by branch:
+
+- `main`, `RAG-integration-branch`: `app/ppt_notes.py` (rebuild loop lives here).
+- `Aggrement`: `app/pptx_rag_quizzer/pptx.py :: rebuild_presentation_with_accessible_features`.
+- `Prod-v1`: follows one of the above depending on the cherry-pick history.
+
+The `check_alt_text_xml` invariant scans all of `app/` for a line that writes `descr` onto `cNvPr`, so moving the rebuild loop between modules is fine — *deleting* the XML write is not.
 
 **Check.**
 

--- a/docs/guardrails/INVARIANTS.md
+++ b/docs/guardrails/INVARIANTS.md
@@ -1,0 +1,180 @@
+# Invariants
+
+Things in this repo will silently break if you violate them. None of these are enforced by the compiler. Most of them are enforced weakly (or not at all) by tests. Read this file before touching parsing, rebuild, Gemini calls, ChromaDB wiring, or `.pptx` XML.
+
+Each invariant has:
+- **Rule** — what must stay true.
+- **Why** — what goes wrong if it doesn't.
+- **Where** — the files it lives in.
+- **Check** — a command or `grep` to validate.
+
+---
+
+## #1 — `order_number` is the universal join key
+
+**Rule.** Every `SlideItem` produced by `parse_powerpoint` / `parse_word` has an `order_number` that maps 1:1 to a shape/element's position in the source document. Rebuild loops must rely on `order_number`, **not** list index, **not** shape iteration order.
+
+**Why.** `python-pptx`'s `slide.shapes` iteration order is *not* guaranteed stable across edits. If you assign alt text by index, you will place it on the wrong shape. This has happened and it is undetectable without visual QA.
+
+**Where.** `app/pptx_rag_quizzer/utils.py` (parse), `app/ppt_notes.py :: process_powerpoint_with_rag_enhanced` (rebuild), `app/models/models.py :: SlideItem.order_number`.
+
+**Check.**
+
+```bash
+rg -n "order_number" app/
+python scripts/check_invariants.py --only order_number
+```
+
+---
+
+## #2 — Alt text goes on `cNvPr/@descr`
+
+**Rule.** When writing alt text to an image shape, set the native XML attribute `cNvPr/@descr` via lxml. Also set `shape.alternative_text` as a fallback for python-pptx tooling.
+
+**Why.** Screen readers (NVDA, JAWS, VoiceOver) read `cNvPr/@descr`. `python-pptx`'s `alternative_text` property sometimes writes to a different location depending on shape type, and is silently ignored by some clients.
+
+**Where.** `app/ppt_notes.py :: process_powerpoint_with_rag_enhanced` → the XML patching block. Look for `cNvPr` and `descr`.
+
+**Check.**
+
+```bash
+rg -n "cNvPr|descr=" app/
+python scripts/check_invariants.py --only alt_text_xml
+```
+
+---
+
+## #3 — Gemini rate-limit: 60 s sleep on `ResourceExhausted`
+
+**Rule.** On `google.api_core.exceptions.ResourceExhausted` (HTTP 429), the call path must sleep **60 seconds** and retry. Do not reduce this interval, do not remove the retry.
+
+**Why.** Gemini free-tier and flash-lite models rate-limit per minute. Shorter backoff busy-loops the quota; no retry drops slides silently.
+
+**Where.** `app/pptx_rag_quizzer/rag_core.py` (retry decorator / loop).
+
+**Check.**
+
+```bash
+rg -n "ResourceExhausted|sleep\(60\)|time.sleep" app/pptx_rag_quizzer/
+```
+
+---
+
+## #4 — ChromaDB access goes through the FastAPI wrapper
+
+**Rule.** Streamlit code must call ChromaDB via HTTP to `chroma-api` (the FastAPI wrapper at `:8001`), not via a direct `chromadb.HttpClient(...)` or `chromadb.PersistentClient(...)`.
+
+**Why.** The wrapper normalizes request shape, handles retries, and isolates dependency upgrades. Bypassing it couples Streamlit to the Chroma client version directly and has broken prod historically when `chromadb` major versions shifted.
+
+**Where.** `app/pptx_rag_quizzer/rag_core.py :: ChromaHTTPClient`. In production the wrapper listens at `http://127.0.0.1:8001` (see [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) §3).
+
+**Check.**
+
+```bash
+rg -n "chromadb\.(Http|Persistent)Client" app/ | grep -v chroma-api
+# expect: only chroma-api/app.py
+```
+
+---
+
+## #5 — Image normalization before hashing or Gemini
+
+**Rule.** Any image bytes flowing into the RAG pipeline must be normalized to PNG or JPG with RGB (not `P` / `RGBA`) color mode before they hit Gemini or ChromaDB hashing.
+
+**Why.** WMF/EMF and paletted PIL images break Gemini's MIME sniffing (400 errors) and cause opaque/black output. Also breaks base64 round-tripping in `Image.image_bytes`.
+
+**Where.** `app/pptx_rag_quizzer/utils.py :: convert_image_to_png_or_jpg`.
+
+**Check.**
+
+```bash
+rg -n "convert_image_to_png_or_jpg|mode\s*==\s*['\"]P['\"]|WMF|EMF" app/
+```
+
+---
+
+## #6 — `chroma/` vector data directory is not to be cleaned in prod
+
+**Rule.** On the production VM, `./chroma/` inside the repo holds persistent vector data. Do **not**:
+- add it to `.gitignore` in a way that it gets `git clean`-ed,
+- `rm -rf chroma/` on the VM,
+- include `chroma/` in a Docker image COPY for dev images.
+
+**Why.** It takes hours to rebuild on large decks, and a wipe has no warning. The path is also hard-coded in `start_scripts/chromadbd.sh`.
+
+**Where.** `/home/mattarama443/Student-Accessible-Powerpoint/chroma/` on prod. `.gitignore` currently lists `/chroma-db` (a different, older path). Confirm both.
+
+**Planned fix.** Move Chroma data outside the repo tree (`/var/lib/chroma-saac/`). Tracked as tech debt §10 below.
+
+**Check.**
+
+```bash
+grep -E "^/?chroma" .gitignore
+```
+
+---
+
+## #7 — `python-pptx` shape traversal must handle groups recursively
+
+**Rule.** Any loop over `slide.shapes` that inspects images or text must recurse into group shapes (`shape.shape_type == MSO_SHAPE_TYPE.GROUP`).
+
+**Why.** Many real-world decks group images with captions. A non-recursive loop silently drops everything inside groups — no alt text, no RAG indexing.
+
+**Where.** `app/pptx_rag_quizzer/utils.py`. On the `Aggrement` branch, `app/pptx_rag_quizzer/pptx.py`.
+
+**Check.**
+
+```bash
+rg -n "MSO_SHAPE_TYPE\.GROUP|is_group|\.shapes\b" app/
+```
+
+---
+
+## #8 — Consent gate is IRB-mandated on `Aggrement`
+
+**Rule.** On the `Aggrement` branch, the consent screen in `app/ppt_notes.py` must be rendered before any file upload UI. Writing to `consent_responses.csv` must continue for every "Agree" click. Do not bypass, shorten, or remove without an IRB amendment.
+
+**Why.** SUNY Brockport IRB approval for the research deployment depends on this gate. Removing it breaks the human-subjects protocol.
+
+**Where.** `app/ppt_notes.py` (Aggrement branch). `consent_responses.csv` on prod.
+
+**Check.**
+
+```bash
+git show Aggrement:app/ppt_notes.py | rg -n "consent|IRB|agree"
+```
+
+---
+
+## #9 — Branch is not landscape, it is a pipeline
+
+**Rule.** Do not merge `Prod-v1`, `Aggrement`, or `nextjs-impl` laterally into each other. See [`BRANCHING.md`](BRANCHING.md).
+
+**Why.** Each branch encodes a different deployment model (Docker vs bare-metal vs Next.js). Cross-merging has historically created subtle 3-way conflicts in `requirements.txt`, config, and parsing.
+
+---
+
+## #10 — Known weaknesses (tech debt)
+
+These are *not yet* invariants — they are known gaps. Closing them is welcome.
+
+| # | Gap | Link |
+|---|---|---|
+| 10.1 | Secrets stored as plaintext `.env` on the VM | [`../ops/SOP_SECRETS.md`](../ops/SOP_SECRETS.md) §5 |
+| 10.2 | `start_scripts/chromadbapi.sh` has `Accessibility` typo (masked by systemd `WorkingDirectory`) | [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) §3.3 |
+| 10.3 | `start_scripts/` and `.streamlit/` live on the VM only — not in git | [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) §6 |
+| 10.4 | GCP firewall `allow-8501` / `allow-8001` expose internal services publicly | [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) §8.4 |
+| 10.5 | `chroma/` vector data inside repo tree (risk of `git clean`) | §6 above |
+| 10.6 | No CI/CD — Jenkins exists on a separate box, unconfigured | [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) §5 |
+| 10.7 | Single prod instance, no LB, no autoscaler | [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) §8.7 |
+| 10.8 | Nginx and systemd unit files not version-controlled | [`../ops/SOP_ROLLBACK.md`](../ops/SOP_ROLLBACK.md) §6 |
+
+Each is a legitimate target for a [`REFACTOR.md`](../templates/REFACTOR.md).
+
+---
+
+## #11 — Configuration of record (emerging invariant)
+
+**Rule (aspirational).** All nginx site configs, all systemd unit files, all startup shell scripts, and the Streamlit config must live in the repo under a `deploy/` directory with an idempotent sync script. Any change on the VM must be mirrored back via PR.
+
+**Status.** Not yet implemented. This is the #1 framework-level refactor we owe ourselves. Until then, any change to these files on the VM **must** also land in an issue with label `drift-upstream`.

--- a/docs/ops/DEPLOY_LOG.md
+++ b/docs/ops/DEPLOY_LOG.md
@@ -1,0 +1,16 @@
+# Deploy Log
+
+One line per prod deploy or rollback. Newest at the top. Keep it terse — post-mortems live in [`INCIDENT_LOG.md`](INCIDENT_LOG.md).
+
+Format:
+
+```
+YYYY-MM-DD HH:MM UTC  <handle>  <old-sha> → <new-sha>  (branch)  notes: <one line>
+YYYY-MM-DD HH:MM UTC  <handle>  ROLLBACK  <bad-sha> → <old-sha>  reason: <one line>
+```
+
+---
+
+<!-- Append new entries above this line. -->
+
+2026-04-22 —  framework  —  n/a → n/a  (docs-only)  notes: initial maintainability framework added (no prod change)

--- a/docs/ops/INCIDENT_LOG.md
+++ b/docs/ops/INCIDENT_LOG.md
@@ -1,0 +1,27 @@
+# Incident Log
+
+One entry per production incident. Newest at the top.
+
+Format:
+
+```
+## YYYY-MM-DD  <short title>
+- Duration: <min>
+- Owner: <handle>
+- Symptom:
+- Root cause:
+- Fix:
+- Prevention action: <issue link or "none filed">
+```
+
+---
+
+<!-- Append new entries above this line. -->
+
+## 2026-04-22  Framework bootstrap (not an incident)
+- Duration: 0 min
+- Owner: framework
+- Symptom: —
+- Root cause: —
+- Fix: —
+- Prevention action: this file created so future incidents have a home.

--- a/docs/ops/SECRET_ROTATION_LOG.md
+++ b/docs/ops/SECRET_ROTATION_LOG.md
@@ -1,0 +1,13 @@
+# Secret Rotation Log
+
+Append-only. Do not rewrite. Never paste a secret value here.
+
+Format:
+
+```
+YYYY-MM-DD  rotated=<VAR_NAME>  operator=<handle>  reason=<scheduled|leak|staffing|initial>
+```
+
+---
+
+<!-- Append new entries above this line. -->

--- a/docs/ops/SOP_DEPLOY.md
+++ b/docs/ops/SOP_DEPLOY.md
@@ -1,0 +1,164 @@
+# SOP: Deploy to Production
+
+**Applies to:** `instance-20250905-023343-pub` (zone `us-central1-c`), deploying branch `Aggrement` to `/home/mattarama443/Student-Accessible-Powerpoint`.
+
+**Audience:** any agent or developer pushing a code change live. Read [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) once before your first deploy.
+
+**Do not skip steps.** This SOP has specific guards against the drift we have already seen on this VM.
+
+---
+
+## 0. Preconditions
+
+- [ ] Your change is merged to `main` and cherry-picked (or merged) into `Aggrement` with a passing PR review.
+- [ ] `python scripts/preflight.py` passes locally on the commit you intend to deploy.
+- [ ] You have `gcloud` auth with `compute.instances.setMetadata` on the prod instance.
+- [ ] It is **not** during a live class / demo window (check with the course owner).
+- [ ] You have a rollback plan (git SHA to roll back to + link to [`SOP_ROLLBACK.md`](SOP_ROLLBACK.md) open in another tab).
+
+If any of the above is not true, STOP.
+
+---
+
+## 1. Prep: capture the current prod state
+
+```bash
+gcloud compute ssh instance-20250905-023343-pub --zone=us-central1-c
+```
+
+Inside the VM:
+
+```bash
+APP=/home/mattarama443/Student-Accessible-Powerpoint
+sudo -u mattarama443 -H bash -lc '
+  cd '"$APP"'
+  echo "=== HEAD before deploy ===";    git -C '"$APP"' rev-parse --short HEAD
+  echo "=== Local modifications ===";   git -C '"$APP"' status -s
+  echo "=== Last 3 commits ===";        git -C '"$APP"' log --oneline -3
+'
+```
+
+**Record the "HEAD before deploy" SHA.** This is your rollback target. Paste it into your deploy issue/PR comment.
+
+If `git status -s` shows modifications, they must be resolved *before* you pull. Historically prod carries uncommitted local edits on `app/ppt_notes.py` and `start_app.py` — see [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) §3.4. Capture the diff first:
+
+```bash
+sudo -u mattarama443 git -C $APP diff > ~/predeploy-drift-$(date +%Y%m%d-%H%M).patch
+sudo -u mattarama443 git -C $APP stash push -u -m "predeploy-$(date +%Y%m%d-%H%M)"
+```
+
+**Do not throw away the patch file.** If any hunk is production-only (server-specific flags, hotfix not yet upstreamed), treat it as a [`../templates/BUG.md`](../templates/BUG.md) to be upstreamed after the deploy.
+
+---
+
+## 2. Pre-deploy smoke test (current state)
+
+From your workstation, before changing anything:
+
+```bash
+python scripts/smoke_test.py --url https://access.brockportsigai.org/accessibility
+```
+
+If the pre-deploy smoke test already fails, you are walking into a broken prod. Stop and follow [`SOP_INCIDENT.md`](SOP_INCIDENT.md) first.
+
+---
+
+## 3. Pull and install
+
+On the VM, as root / with sudo:
+
+```bash
+APP=/home/mattarama443/Student-Accessible-Powerpoint
+sudo -u mattarama443 -H bash -lc '
+  cd '"$APP"'
+  git fetch origin
+  git checkout Aggrement
+  git pull --ff-only origin Aggrement
+  source venv/bin/activate
+  pip install -r requirements.txt
+'
+```
+
+`--ff-only` is mandatory. If it refuses, the tree is dirty or someone committed on the VM — go back to §1.
+
+**If `requirements.txt` did not change**, you can skip `pip install` — but it is cheap and safe to run.
+
+---
+
+## 4. Re-apply production-only patches (if any were stashed)
+
+Only if §1 produced a `.patch` file that contains production-only edits (not yet upstreamed):
+
+```bash
+sudo -u mattarama443 git -C $APP apply --index ~/predeploy-drift-YYYYMMDD-HHMM.patch
+```
+
+Resolve any conflicts manually. File an issue tagged `drift-upstream` to move those edits into git.
+
+---
+
+## 5. Restart services (order matters)
+
+```bash
+sudo systemctl restart chromadbd              # 1. vector DB
+sleep 3
+sudo systemctl restart chromadbapi            # 2. FastAPI wrapper
+sleep 2
+sudo systemctl restart student-access-ppt    # 3. Streamlit
+```
+
+Watch boot logs for the Streamlit service:
+
+```bash
+sudo journalctl -u student-access-ppt -n 50 -f
+# Ctrl-C when you see "You can now view your Streamlit app..."
+```
+
+---
+
+## 6. Post-deploy smoke test (required gate)
+
+From your workstation:
+
+```bash
+python scripts/smoke_test.py --url https://access.brockportsigai.org/accessibility --strict
+```
+
+Expected: exit code 0 with all checks green. If any check fails, **immediately** follow [`SOP_ROLLBACK.md`](SOP_ROLLBACK.md).
+
+Additionally, open the site in a browser and verify the four-stage UI renders: upload → describe images → final processing → download.
+
+---
+
+## 7. Record the deploy
+
+Append a line to `docs/ops/DEPLOY_LOG.md` (commit on `main`):
+
+```
+YYYY-MM-DD HH:MM UTC  <your-handle>  <old-sha> → <new-sha>  (prod Aggrement)  notes: <one line>
+```
+
+If you had to re-apply a drift patch in §4, link the patch filename here as well.
+
+---
+
+## 8. When *not* to use this SOP
+
+- **Docker deploy?** There is no Docker deploy for this app in prod. The `Prod-v1` branch's `docker-compose.yml` is not the deployed topology. Do not follow this SOP to apply it; that is a migration project, not a deploy.
+- **Static content only?** If you only changed `/var/www/streamlit-home/index.html`, the landing page, you can edit it in place and `sudo systemctl reload nginx`. But add the file to git at the same time — landing-page drift is a recurring problem.
+- **Secret rotation?** Use [`SOP_SECRETS.md`](SOP_SECRETS.md) instead.
+
+---
+
+## 9. Failure modes you will actually hit
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `git pull` refuses with "local changes" | Someone edited on the VM | §1 stash → re-apply |
+| `pip install` fails on `google-generativeai` | Python ABI mismatch after OS update | `rm -rf venv && python3.11 -m venv venv && source venv/bin/activate && pip install -r requirements.txt` |
+| Streamlit says `Error: port 8501 already in use` | Previous process did not die | `sudo systemctl stop student-access-ppt && sudo pkill -f streamlit && sudo systemctl start student-access-ppt` |
+| `curl localhost:8001/health` returns 404 | `chromadbapi.sh` typo bit you (the `cd` fails, and something else changed `WorkingDirectory`) | Fix the script: `cd /home/mattarama443/Student-Accessible-Powerpoint` (not `Accessibility`) |
+| 502 from nginx after restart | Streamlit still booting; give it 15 s | Re-run the smoke test |
+| Gemini quota exhausted during smoke | Daily quota hit by the test itself | Acceptable — the smoke test is `--lite` by default and does not call Gemini |
+
+See also [`SOP_INCIDENT.md`](SOP_INCIDENT.md).

--- a/docs/ops/SOP_INCIDENT.md
+++ b/docs/ops/SOP_INCIDENT.md
@@ -1,0 +1,152 @@
+# SOP: Production Incident Response
+
+**Scope:** any situation where `https://access.brockportsigai.org/accessibility` is unavailable, returning errors, or producing clearly wrong output.
+
+**Target instance:** `instance-20250905-023343-pub` / `us-central1-c`.
+
+---
+
+## 1. First 60 seconds
+
+Pick one:
+
+- [ ] Can you open `https://access.brockportsigai.org/accessibility` in a browser? → no / yes?
+- [ ] Does `python scripts/smoke_test.py --url https://access.brockportsigai.org/accessibility` pass? → which check failed?
+
+Based on that, jump to the matching section below.
+
+**If you cannot answer either question (network blocked, etc.)**, skip to §7 (escalation) — do not guess at fixes blind.
+
+---
+
+## 2. Symptom matrix
+
+| Symptom | First probe | Section |
+|---|---|---|
+| Site does not respond at all (connection refused / timeout) | `gcloud compute instances describe instance-20250905-023343-pub --zone=us-central1-c --format='value(status)'` | §3 |
+| Site responds but shows `502 Bad Gateway` / `503` | Streamlit is down. Check systemd. | §4 |
+| Site responds but shows Streamlit error page ("Oh no.") | App crashed. Check journalctl. | §5 |
+| Site renders but Gemini calls error out | API key / quota | §6 |
+| Site renders but ChromaDB calls error out | chromadbd / chromadbapi | §5 |
+| TLS cert warning | certbot renewal failed | §8 |
+
+---
+
+## 3. VM down
+
+```bash
+gcloud compute instances describe instance-20250905-023343-pub --zone=us-central1-c --format='value(status)'
+```
+
+- If `TERMINATED`: `gcloud compute instances start instance-20250905-023343-pub --zone=us-central1-c`, then wait 60 s and retry smoke test.
+- If `STOPPING`: wait; retry in 60 s.
+- If `RUNNING` but unreachable: GCP networking issue. Check `gcloud compute instances get-serial-port-output ...` and escalate (§7).
+
+On startup, systemd brings up `chromadbd → chromadbapi → student-access-ppt` automatically. If any unit failed, §4 applies.
+
+---
+
+## 4. Service crashed / unit failed
+
+SSH in and check:
+
+```bash
+sudo systemctl status chromadbd chromadbapi student-access-ppt --no-pager
+```
+
+For any unit in `failed` state:
+
+```bash
+sudo journalctl -u <unit-name> -n 200 --no-pager
+sudo systemctl restart <unit-name>
+sudo systemctl status <unit-name> --no-pager
+```
+
+Order of restart if multiple failed: `chromadbd` → `chromadbapi` → `student-access-ppt`.
+
+**If `chromadbapi.service` keeps failing with "no such file":** it is probably the `Student-Accessibility-Powerpoint` typo in `start_scripts/chromadbapi.sh`. Confirm:
+
+```bash
+sudo cat /home/mattarama443/Student-Accessible-Powerpoint/start_scripts/chromadbapi.sh
+```
+
+Fix the typo (`Accessibility` → `Accessible`). Full detail: [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) §3.3.
+
+---
+
+## 5. App logs point at a code bug
+
+```bash
+sudo journalctl -u student-access-ppt -n 500 --no-pager | less
+```
+
+Look for `Traceback`. Common signatures:
+
+| Traceback contains | Likely cause | Action |
+|---|---|---|
+| `KeyError: 'order_number'` | Parsing regression broke invariant #1 | Rollback ([`SOP_ROLLBACK.md`](SOP_ROLLBACK.md)) |
+| `PIL.UnidentifiedImageError` | WMF/EMF not normalized | Check `app/pptx_rag_quizzer/utils.py` image conversion |
+| `google.api_core.exceptions.ResourceExhausted` | Gemini quota | §6 |
+| `chromadb.errors.*` | Chroma down or collection corrupted | §4 + [`SOP_ROLLBACK.md`](SOP_ROLLBACK.md) §5 |
+| `streamlit.runtime.scriptrunner.script_runner.RerunException` | Not a real error, ignore | — |
+| `AttributeError: 'Shape' object has no attribute '...'` | python-pptx version mismatch | `pip install -r requirements.txt` |
+
+If the last deploy is the likely cause → [`SOP_ROLLBACK.md`](SOP_ROLLBACK.md).
+
+---
+
+## 6. Gemini issues
+
+Check the last error:
+
+```bash
+sudo journalctl -u student-access-ppt --since "1 hour ago" | grep -iE "gemini|google.api_core|GOOGLE_API_KEY|ResourceExhausted|PermissionDenied"
+```
+
+- **`ResourceExhausted` (429)**: Daily quota hit. The app already sleeps 60 s on this — no action unless the whole day is exhausted. If so, it will auto-recover at the quota reset; alternatively, rotate to a higher-tier key following [`SOP_SECRETS.md`](SOP_SECRETS.md).
+- **`PermissionDenied` (401/403)**: Key revoked or missing. Rotate — [`SOP_SECRETS.md`](SOP_SECRETS.md).
+- **`InvalidArgument` on model name**: Someone changed `gemini-2.0-flash-lite` → unknown model. Rollback.
+
+---
+
+## 7. Escalate
+
+If §3–6 do not resolve it in **15 minutes**:
+
+1. Post the current symptom, the last 50 lines of `journalctl -u student-access-ppt`, and the `gcloud instances describe` output to the team channel.
+2. Mention the course owner if a live class is in session.
+3. If DNS is broken, you can temporarily redirect users to the old instance (`instance-20250610-144049`, `35.196.195.118`) — but it is HTTP-only and has no systemd, so it needs manual start (`nohup venv/bin/streamlit run ...`). See [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) §4.
+
+---
+
+## 8. TLS issues
+
+```bash
+sudo certbot certificates
+sudo journalctl -u certbot.service --since "7 days ago"
+```
+
+Manual renewal:
+
+```bash
+sudo certbot renew --nginx
+sudo systemctl reload nginx
+```
+
+If certbot can't reach Let's Encrypt, check that port 80 is still open in the GCP firewall (`default-allow-http`) — ACME HTTP-01 uses it.
+
+---
+
+## 9. Close out
+
+Every incident that lasted more than a brief blip must produce a short post-incident note in `docs/ops/INCIDENT_LOG.md`:
+
+```
+YYYY-MM-DD  duration=<min>  owner=<handle>
+Symptom:
+Root cause:
+Fix:
+Prevention action (ticket link):
+```
+
+If the prevention action is a code or infra change, file it as a [`BUG.md`](../templates/BUG.md) or [`REFACTOR.md`](../templates/REFACTOR.md) immediately.

--- a/docs/ops/SOP_ROLLBACK.md
+++ b/docs/ops/SOP_ROLLBACK.md
@@ -1,0 +1,134 @@
+# SOP: Rollback a Production Deploy
+
+**When to use:** immediately after a deploy if the smoke test fails, or at any time prod is broken and the last deploy is the likely cause.
+
+**Target instance:** `instance-20250905-023343-pub` / `us-central1-c` / branch `Aggrement`.
+
+**Required:** the "HEAD before deploy" SHA you recorded in [`SOP_DEPLOY.md`](SOP_DEPLOY.md) §1. If you did not record it, get it from `git reflog`.
+
+---
+
+## 1. Decide: rollback or forward-fix?
+
+| Situation | Action |
+|---|---|
+| Smoke test failed, no user has hit the site since the deploy | **Rollback.** Fast and cheap. |
+| Users are on the site right now and the bug is cosmetic | **Forward-fix.** Open an incident ([`SOP_INCIDENT.md`](SOP_INCIDENT.md)) and push a hotfix. |
+| Gemini API key issue | Not a code problem. See [`SOP_SECRETS.md`](SOP_SECRETS.md). |
+| Prod is hard-down (502, process crash looping) | **Rollback first, diagnose later.** |
+
+If in doubt: rollback. Downtime > serving wrong data.
+
+---
+
+## 2. Rollback (Python/git)
+
+SSH in:
+
+```bash
+gcloud compute ssh instance-20250905-023343-pub --zone=us-central1-c
+```
+
+Revert the repo to the previous SHA:
+
+```bash
+APP=/home/mattarama443/Student-Accessible-Powerpoint
+OLD_SHA=<paste-your-pre-deploy-sha>
+
+sudo -u mattarama443 -H bash -lc '
+  cd '"$APP"'
+  git fetch origin
+  git checkout Aggrement
+  git reset --hard '"$OLD_SHA"'
+  source venv/bin/activate
+  pip install -r requirements.txt
+'
+```
+
+Restart the three services in order:
+
+```bash
+sudo systemctl restart chromadbd
+sleep 3
+sudo systemctl restart chromadbapi
+sleep 2
+sudo systemctl restart student-access-ppt
+```
+
+---
+
+## 3. Confirm rollback
+
+From your workstation:
+
+```bash
+python scripts/smoke_test.py --url https://access.brockportsigai.org/accessibility --strict
+```
+
+Open the site and verify it renders. Attempt a trivial upload.
+
+---
+
+## 4. Rollback a dependency change
+
+If the failing deploy changed `requirements.txt`, `git reset --hard` alone does not always restore the venv (pip rarely removes packages). The nuclear option is safe here:
+
+```bash
+sudo -u mattarama443 -H bash -lc '
+  cd '"$APP"'
+  rm -rf venv
+  python3.11 -m venv venv
+  source venv/bin/activate
+  pip install -r requirements.txt
+'
+sudo systemctl restart chromadbd chromadbapi student-access-ppt
+```
+
+Takes ~2–3 minutes. Do this if the rollback leaves the app in a "ModuleNotFoundError" state.
+
+---
+
+## 5. Rollback a ChromaDB schema change
+
+Chroma's vector data lives at `/home/mattarama443/Student-Accessible-Powerpoint/chroma/`. If the deploy silently broke the collection layout (rare — only on `chromadb` major bumps):
+
+```bash
+sudo systemctl stop chromadbd chromadbapi student-access-ppt
+sudo -u mattarama443 mv $APP/chroma $APP/chroma.broken-$(date +%s)
+sudo -u mattarama443 mkdir $APP/chroma
+sudo systemctl start chromadbd chromadbapi student-access-ppt
+```
+
+This is equivalent to "fresh RAG index"; the app seeds it lazily on first upload. The app will be slower on cold start but functionally correct. **Do not delete the `.broken-*` directory** until the incident is closed — it is your forensic copy.
+
+---
+
+## 6. Rollback nginx / systemd unit changes
+
+Unit files and nginx configs are **not in git** on production. If the deploy touched them:
+
+```bash
+# nginx
+sudo cp /etc/nginx/sites-enabled/streamlit-https /etc/nginx/sites-enabled/streamlit-https.broken
+sudo nano /etc/nginx/sites-enabled/streamlit-https    # manually revert
+sudo nginx -t && sudo systemctl reload nginx
+
+# systemd
+sudo nano /etc/systemd/system/student-access-ppt.service
+sudo systemctl daemon-reload
+sudo systemctl restart student-access-ppt
+```
+
+**After the incident closes:** open a [`REFACTOR.md`](../templates/REFACTOR.md) to track `/etc/nginx/sites-enabled/*` and `/etc/systemd/system/*.service` in git (see Invariant #11 in [`../guardrails/INVARIANTS.md`](../guardrails/INVARIANTS.md)).
+
+---
+
+## 7. Record the rollback
+
+Append to `docs/ops/DEPLOY_LOG.md`:
+
+```
+YYYY-MM-DD HH:MM UTC  <your-handle>  ROLLBACK  <bad-sha> → <old-sha>  reason: <one line>
+```
+
+Then open an issue using [`../templates/BUG.md`](../templates/BUG.md) so the faulty change can be fixed forward cleanly.

--- a/docs/ops/SOP_SECRETS.md
+++ b/docs/ops/SOP_SECRETS.md
@@ -1,0 +1,105 @@
+# SOP: Secret Rotation & Management
+
+**In scope:** `GOOGLE_API_KEY` (the only runtime secret we have today), TLS certificates (covered in [`SOP_INCIDENT.md`](SOP_INCIDENT.md) §8), and future secrets.
+
+**Current storage:** `.env` file on the production VM at `/home/mattarama443/Student-Accessible-Powerpoint/.env`. Plaintext, 0600, owned by `mattarama443`. No Vault, no Secret Manager. This is a known weakness — see §5.
+
+---
+
+## 1. Rotate `GOOGLE_API_KEY`
+
+### 1.1 Create the new key
+
+- Console → Google AI Studio / Vertex AI → create a new API key scoped to the same project/model (`gemini-2.0-flash-lite`).
+- Label it with the date and operator, e.g. `sigai-prod-2026-04-22-dal`.
+
+Do **not** disable the old key yet. You need both live briefly for a zero-downtime swap.
+
+### 1.2 Deploy the new key
+
+```bash
+gcloud compute ssh instance-20250905-023343-pub --zone=us-central1-c
+APP=/home/mattarama443/Student-Accessible-Powerpoint
+sudo -u mattarama443 cp $APP/.env $APP/.env.bak-$(date +%Y%m%d-%H%M)
+sudo -u mattarama443 nano $APP/.env        # replace GOOGLE_API_KEY value
+sudo systemctl restart student-access-ppt
+```
+
+Wait 15 seconds. Then:
+
+```bash
+python scripts/smoke_test.py --url https://access.brockportsigai.org/accessibility --strict
+```
+
+Open the site, upload a small test deck, and confirm alt text is generated for at least one image (proves the Gemini call path).
+
+### 1.3 Disable the old key
+
+Only **after** the smoke test passes and you have seen a successful Gemini response in the logs:
+
+- Console → revoke the old key.
+- Delete the `.env.bak-*` files on the VM (`sudo -u mattarama443 rm $APP/.env.bak-*`).
+
+### 1.4 Record it
+
+Append to `docs/ops/SECRET_ROTATION_LOG.md`:
+
+```
+YYYY-MM-DD  rotated=GOOGLE_API_KEY  operator=<handle>  reason=<scheduled|leak|staffing>
+```
+
+Never paste the key value in the log. The log is public-visible in git.
+
+---
+
+## 2. Add a new secret
+
+If a feature requires a new secret (e.g. OAuth client secret, database password):
+
+1. Add the **variable name** (not value) to `.env.example`.
+2. Document it in [`../AGENT_CONTEXT.md`](../AGENT_CONTEXT.md) "Stable facts" section.
+3. Reference it from code via `os.environ` (or `pydantic-settings`), never hard-code.
+4. Deploy: append the variable to `/home/mattarama443/Student-Accessible-Powerpoint/.env` on the VM and `systemctl restart student-access-ppt`.
+5. If the secret rotates routinely (e.g. >1× / year), add a section to this SOP.
+
+Never:
+- commit a real secret value to any branch,
+- log a secret,
+- bake a secret into a Docker image or systemd unit `Environment=` line.
+
+---
+
+## 3. Handling a suspected leak
+
+If you believe a key has been exposed (accidentally committed, logged, screenshotted, shared in a ticket):
+
+1. **Rotate the key immediately** — §1, but with zero grace period. Revoke the old key *before* confirming the smoke test if the exposure is public.
+2. **Scan the git history** for the leaked value:
+
+   ```bash
+   git log --all -p -S '<first-few-chars-of-key>' | head -100
+   ```
+
+   If found in git, the repo is compromised. A rotation is sufficient remediation *only* if the old key is revoked; do **not** try to rewrite history on the shared remote without team agreement.
+3. **File an incident** — [`SOP_INCIDENT.md`](SOP_INCIDENT.md) §9 — with root cause = "secret leak".
+4. **Search for further exposure**: logs (`journalctl --since "2 weeks ago" | grep -i '<key-pattern>'`), screenshots, Slack/Discord, PRs.
+
+---
+
+## 4. TLS private keys
+
+Managed by certbot at `/etc/letsencrypt/live/access.brockportsigai.org/`. Rotate automatically via `certbot.timer`. Manual intervention steps are in [`SOP_INCIDENT.md`](SOP_INCIDENT.md) §8.
+
+**Never back up the private key to anywhere outside the VM.**
+
+---
+
+## 5. Known gaps (planned improvements)
+
+These are tracked as tech debt; see `docs/guardrails/INVARIANTS.md` §10.
+
+- **Plaintext `.env`**: migrate to GCP Secret Manager + a small runtime loader. Proposal: a `REFACTOR.md` titled "Move secrets to GCP Secret Manager" — this has not been filed yet.
+- **No leaked-secret scanner in CI**: add `detect-secrets` or `trufflehog` to `.github/workflows/` once CI exists.
+- **No audit log**: secret rotations are only captured by `SECRET_ROTATION_LOG.md` (this SOP). A GCP IAM audit trail covers only the console-side actions.
+
+If you are the agent picking up this work: start with Secret Manager migration; it closes the highest-severity gap.

--- a/docs/templates/BUG.md
+++ b/docs/templates/BUG.md
@@ -1,0 +1,83 @@
+# Bug Report / Fix Template
+
+> **Purpose.** Agent-optimized template for reporting *and* fixing a defect. If you are reporting, fill §§1–4. If you are fixing, fill §§5–10 too. Copy this file into the issue/PR and delete this block.
+
+---
+
+## 1. TL;DR
+
+One sentence: what's wrong.
+
+## 2. Environment
+
+- [ ] Local dev (Windows / macOS / Linux)
+- [ ] Production (`access.brockportsigai.org/accessibility`)
+- [ ] Older prod instance (`35.196.195.118`)
+- [ ] Other (describe)
+
+- Branch / commit observed on: …
+- Python version, OS, browser if UI bug: …
+
+## 3. Repro
+
+Exact steps. Include the input artifact (`.pptx` filename / source) if relevant.
+
+1. 
+2. 
+3. 
+
+**Expected:** …
+**Actual:** …
+
+## 4. Evidence
+
+- Screenshot / recording: …
+- Stack trace (from `journalctl -u student-access-ppt` if prod, or local terminal): paste in a code block
+- `consent_responses.csv` / `chroma/` effects (if relevant):
+
+```text
+<paste traceback or log excerpt here>
+```
+
+---
+
+*(Everything below is for the fix PR.)*
+
+## 5. Root cause
+
+A paragraph: *why* this happens. Not the fix yet. Tie it back to the code path — which module, which function, which invariant broke.
+
+- Invariant violated (if any, from [`../guardrails/INVARIANTS.md`](../guardrails/INVARIANTS.md)): …
+- Regression introduced in commit: `<sha>` (use `git log -p -S <symbol>`)
+- Branches affected: `main` / `Aggrement` / `Prod-v1` / …
+
+## 6. Fix
+
+Summary of the change. Link the diff. If the fix is only on one branch but the bug exists on another, describe the cherry-pick plan ([`../guardrails/BRANCHING.md`](../guardrails/BRANCHING.md)).
+
+## 7. Test that would have caught this
+
+Every bug fix adds a regression test. Exceptions must be justified.
+
+- [ ] Unit test added in `tests/…`
+- [ ] Invariant check added in `scripts/check_invariants.py`
+- [ ] Smoke test updated in `scripts/smoke_test.py`
+- [ ] N/A — justification: …
+
+## 8. Risk
+
+- **Blast radius of the fix:** local | prod | both
+- **Could the fix introduce a new regression?** In which module?
+- **Rollback plan:** see [`../ops/SOP_ROLLBACK.md`](../ops/SOP_ROLLBACK.md).
+
+## 9. Deployment
+
+- [ ] Needs production deploy — follow [`../ops/SOP_DEPLOY.md`](../ops/SOP_DEPLOY.md)
+- [ ] Urgency (hotfix now / next regular deploy / low-priority):
+- [ ] Incident already open ([`../ops/INCIDENT_LOG.md`](../ops/INCIDENT_LOG.md)): yes (link) / no
+
+## 10. Post-merge
+
+- [ ] DEPLOY_LOG.md entry added.
+- [ ] INCIDENT_LOG.md closed (if an incident was open).
+- [ ] [`../AGENT_CONTEXT.md`](../AGENT_CONTEXT.md) footgun section updated if the bug exposed a new trap.

--- a/docs/templates/FEATURE.md
+++ b/docs/templates/FEATURE.md
@@ -1,0 +1,127 @@
+# Feature Request / Implementation Template
+
+> **Purpose.** This template is agent-optimized. A future AI agent should be able to read a filled-out copy and know exactly what to build, how to scope it, and what *not* to touch. Copy this file into the issue or PR description. Delete this block.
+
+---
+
+## 1. Summary (≤ 3 sentences)
+
+*What does the user / stakeholder gain when this ships? No solution hints here — just the outcome.*
+
+Example: "Users can upload `.docx` files alongside `.pptx` and receive the same accessibility treatment in the same UI flow."
+
+## 2. Motivation
+
+- **Who asked for this?** (course owner, researcher, IRB, user report)
+- **Why now?**
+- **What evidence do we have that this is needed?** (issue link, class transcript, WCAG audit, etc.)
+
+## 3. Scope
+
+### In scope
+- *One bullet per capability.*
+
+### Out of scope
+- *Explicit exclusions. Use this to prevent scope creep.*
+
+## 4. User-visible contract
+
+Describe the change from the user's point of view. A checklist is fine.
+
+- [ ] UI: what new controls / screens appear and where?
+- [ ] Input: what formats / sizes are accepted?
+- [ ] Output: what artifact is produced and downloadable?
+- [ ] Copy: any IRB-relevant language? (consent screens, disclaimers)
+
+## 5. Technical design
+
+### 5.1 Branch
+
+Which branch does this target and why? See [`../guardrails/BRANCHING.md`](../guardrails/BRANCHING.md).
+
+- `main` | `Aggrement` | `Prod-v1` | `nextjs-impl`
+- Cherry-pick plan (if cross-branch):
+
+### 5.2 Files I expect to touch
+
+Based on [`../AGENT_CONTEXT.md`](../AGENT_CONTEXT.md) repository map:
+
+- `app/ppt_notes.py` — why
+- `app/pptx_rag_quizzer/<mod>.py` — why
+- `app/models/models.py` — why (new fields? keep invariants)
+- `requirements.txt` / `requirements-app.txt` — new deps?
+- `docs/…` — what needs to be updated
+
+### 5.3 Data model changes
+
+- New Pydantic fields: …
+- New ChromaDB collection / schema: …
+- Migration required: yes / no
+
+### 5.4 External calls
+
+- New Gemini model / prompt? → respects invariant #3 (60 s backoff)? [y/n]
+- New ChromaDB endpoints? → added to the FastAPI wrapper (invariant #4)? [y/n]
+- New secrets? → added to `.env.example` + [`../ops/SOP_SECRETS.md`](../ops/SOP_SECRETS.md)? [y/n]
+
+### 5.5 Invariants audit
+
+From [`../guardrails/INVARIANTS.md`](../guardrails/INVARIANTS.md), tick each that this change touches and state how it preserves the invariant.
+
+- [ ] #1 `order_number`
+- [ ] #2 `cNvPr/@descr`
+- [ ] #3 Gemini 60 s sleep
+- [ ] #4 Chroma via FastAPI wrapper
+- [ ] #5 Image normalization
+- [ ] #6 `chroma/` data safety
+- [ ] #7 Recursive group traversal
+- [ ] #8 Consent gate (Aggrement only)
+
+## 6. Accessibility (WCAG 2.1 AA)
+
+- **Does this affect alt text quality?** How?
+- **Does this affect reading order?** How?
+- **Does this affect contrast / color reliance?** How?
+- **Evidence of compliance:** (PowerPoint Accessibility Checker screenshot, screen-reader recording, etc.)
+
+## 7. Risks & rollback
+
+- **Blast radius:** local | prod | both
+- **Worst-case failure:** …
+- **Rollback plan:** see [`../ops/SOP_ROLLBACK.md`](../ops/SOP_ROLLBACK.md); rollback SHA will be recorded at deploy time.
+
+## 8. Testing plan
+
+- [ ] Unit test(s): …
+- [ ] Manual QA: upload an exemplar deck, verify … 
+- [ ] Smoke test update needed (`scripts/smoke_test.py`): yes / no
+- [ ] Accessibility check: PowerPoint Accessibility Checker on the output deck
+
+## 9. Docs plan
+
+- [ ] Update [`../AGENT_CONTEXT.md`](../AGENT_CONTEXT.md) (agent-facing facts)
+- [ ] Update [`../PROJECT_OVERVIEW.md`](../PROJECT_OVERVIEW.md) (human narrative)
+- [ ] Update [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) (if infra changes)
+- [ ] Add/update invariant in [`../guardrails/INVARIANTS.md`](../guardrails/INVARIANTS.md)?
+
+## 10. Deployment plan
+
+- [ ] Local only — no deploy needed
+- [ ] Prod deploy required — follow [`../ops/SOP_DEPLOY.md`](../ops/SOP_DEPLOY.md)
+- [ ] Backfill / migration step needed: describe
+- [ ] Secret rotation piggy-backed: see [`../ops/SOP_SECRETS.md`](../ops/SOP_SECRETS.md)
+
+## 11. Open questions
+
+*Anything you want the reviewer (or the next agent) to answer before coding starts.*
+
+---
+
+## Definition of done
+
+- [ ] Code merged on the target branch.
+- [ ] All items in §5.5 (invariants) and §6 (accessibility) verified.
+- [ ] Pre-merge checklist complete ([`../guardrails/CHANGE_CHECKLIST.md`](../guardrails/CHANGE_CHECKLIST.md)).
+- [ ] Docs updated.
+- [ ] Deployed (if applicable) with a line in [`../ops/DEPLOY_LOG.md`](../ops/DEPLOY_LOG.md).
+- [ ] Smoke test green post-deploy.

--- a/docs/templates/REFACTOR.md
+++ b/docs/templates/REFACTOR.md
@@ -1,0 +1,98 @@
+# Refactor Template
+
+> **Purpose.** For structural changes that do **not** alter user-visible behavior: renaming, module splits, type hints, extracting helpers, moving config into git, promoting a branch, etc. Copy into the issue/PR and delete this block.
+
+A change that intentionally alters behavior is a [`FEATURE`](FEATURE.md) or [`BUG`](BUG.md), not a refactor. Be strict about this.
+
+---
+
+## 1. TL;DR
+
+One sentence: what shape changes, and why behavior stays identical.
+
+## 2. Motivation
+
+Why now? Pick at least one:
+
+- [ ] Closes a tech-debt item (link to [`../guardrails/INVARIANTS.md`](../guardrails/INVARIANTS.md) §10 entry)
+- [ ] Unblocks a planned feature — name it
+- [ ] Reduces footgun risk (link to [`../AGENT_CONTEXT.md`](../AGENT_CONTEXT.md) footgun)
+- [ ] Enforces an invariant in code instead of docs
+- [ ] Other (describe)
+
+## 3. Scope
+
+### In scope (structural changes)
+- …
+
+### Strictly out of scope
+- Any behavior change. If reviewers detect one, this PR gets rejected as "refactor + feature bundled".
+
+## 4. Branch
+
+Per [`../guardrails/BRANCHING.md`](../guardrails/BRANCHING.md):
+
+- Target: …
+- Cross-branch plan (almost always `main` first, then cherry-pick to `Aggrement`):
+
+## 5. Before/after
+
+- **Before** (paste current layout / signature / structure, or link to it):
+
+```
+<current>
+```
+
+- **After** (paste new):
+
+```
+<new>
+```
+
+## 6. Invariant safety
+
+This is the whole point of the refactor template. For each, explain why it still holds after the refactor.
+
+- [ ] #1 `order_number`
+- [ ] #2 `cNvPr/@descr` XML path
+- [ ] #3 Gemini 60 s sleep
+- [ ] #4 Chroma via FastAPI wrapper
+- [ ] #5 Image normalization
+- [ ] #6 `chroma/` safety
+- [ ] #7 Recursive group traversal
+- [ ] #8 Consent gate (Aggrement)
+
+If a refactor makes an invariant *impossible to violate* (e.g. encodes it as a type), update [`../guardrails/INVARIANTS.md`](../guardrails/INVARIANTS.md) to note the code enforcement and change the Check to reference the test.
+
+## 7. Equivalence evidence
+
+How do we know behavior didn't change?
+
+- [ ] Existing tests still pass (paste `pytest` output).
+- [ ] New behavior-parity tests (e.g. same input deck → byte-identical or diff-only-in-whitespace output):
+- [ ] Manual round-trip: same deck before/after produced same alt text set.
+- [ ] `scripts/smoke_test.py` passes against the refactored build.
+
+## 8. Risk
+
+- **Blast radius:** small | medium | large
+- **Most likely regression surface:** …
+- **Rollback:** revert PR; if production-deployed, see [`../ops/SOP_ROLLBACK.md`](../ops/SOP_ROLLBACK.md).
+
+## 9. Deployment
+
+- [ ] No prod deploy (pure code refactor on `main`).
+- [ ] Prod deploy required — follow [`../ops/SOP_DEPLOY.md`](../ops/SOP_DEPLOY.md) and treat it like a regular deploy.
+
+## 10. Docs updates
+
+- [ ] [`../AGENT_CONTEXT.md`](../AGENT_CONTEXT.md) — repository map if modules moved.
+- [ ] [`../PROJECT_OVERVIEW.md`](../PROJECT_OVERVIEW.md) — architecture diagram if it changes.
+- [ ] [`../guardrails/INVARIANTS.md`](../guardrails/INVARIANTS.md) — note if the refactor closes a tech-debt item (§10) or encodes an invariant in code.
+- [ ] [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) — if deployment shape changes (systemd unit rename, nginx route rename, directory moves).
+
+## 11. Follow-ups
+
+Refactors often expose more debt. List follow-ups here as separate issues so they don't sneak into this PR.
+
+- …

--- a/docs/templates/UPDATE.md
+++ b/docs/templates/UPDATE.md
@@ -1,0 +1,76 @@
+# Update Template (dependency / version bumps, config changes)
+
+> **Purpose.** Agent-optimized template for changes that alter versions, dependencies, configuration, or minor behavior of an existing capability — without adding a new user-visible feature. Copy into the issue/PR and delete this block.
+
+Common uses: Python dep bump, Gemini model change, `client_max_body_size` tweak, Chroma version bump, Streamlit version bump, firewall rule edit.
+
+---
+
+## 1. TL;DR
+
+One sentence: what's being updated and why.
+
+## 2. What changes
+
+- **Package / model / config:** e.g. `chromadb 1.5.7 → 1.6.0`
+- **Scope:** `requirements.txt`, `requirements-app.txt`, `.streamlit/config.toml`, firewall, systemd, nginx — pick the files.
+- **Expected behavior change (if any):** …
+- **Expected behavior that must stay identical:** …
+
+## 3. Motivation
+
+- **Trigger:** security advisory | CVE | upstream deprecation | feature we need | sysadmin request
+- **Link:** CVE ID, release notes URL, advisory URL
+
+## 4. Branch
+
+Per [`../guardrails/BRANCHING.md`](../guardrails/BRANCHING.md):
+
+- Target branch: …
+- If this is a version bump, confirm the *same* bump is applied (or skipped) on each of: `main`, `Aggrement`, `Prod-v1`. Pick one:
+  - [ ] `main` only (canonical)
+  - [ ] `main` + `Aggrement` (standard prod update)
+  - [ ] `Prod-v1` only (Docker branch)
+  - [ ] All branches (rare)
+
+## 5. Compatibility audit
+
+- [ ] I read the upstream changelog from the current pin → new pin.
+- [ ] Breaking changes identified:
+- [ ] Deprecations that will bite us at the **next** bump:
+
+### Specific risk checks
+
+- [ ] `python-pptx` changes — do they affect group traversal (invariant #7) or XML serialization (invariant #2)?
+- [ ] `chromadb` changes — do they require a collection migration? (See [`../ops/SOP_ROLLBACK.md`](../ops/SOP_ROLLBACK.md) §5.)
+- [ ] `google-generativeai` changes — does the Gemini model name / endpoint still resolve?
+- [ ] `fastapi` / `pydantic` changes — do our models in `app/models/models.py` still validate?
+- [ ] `Pillow` changes — does `P` → `RGB` still work for our WMF/EMF path (invariant #5)?
+- [ ] `streamlit` changes — does `baseUrlPath=accessibility` still route under nginx?
+
+## 6. Test plan
+
+- [ ] Full local stack restarted with new deps; `.pptx` end-to-end round-trip works.
+- [ ] `python scripts/check_invariants.py` passes.
+- [ ] `python -m pytest -q` passes.
+- [ ] `python scripts/preflight.py` passes.
+- [ ] Manual check of each invariant in §5 that I flagged "yes".
+
+## 7. Prod considerations
+
+- [ ] `pip install -r requirements.txt` on the VM (see [`../ops/SOP_DEPLOY.md`](../ops/SOP_DEPLOY.md) §3).
+- [ ] If this is a major version bump, I plan to `rm -rf venv && python3.11 -m venv venv && ...` instead of in-place upgrade. (`pip install` rarely removes packages cleanly.)
+- [ ] If this changes Gemini model: I've coordinated with the course owner on cost/quota implications.
+- [ ] If this changes nginx / systemd / firewall: I've noted that those files live on the VM, not in git (invariant #11), and I've captured the diff.
+
+## 8. Rollback
+
+- Rollback is usually "revert the PR, restart services". Call out deviations:
+  - If the update pushed a Chroma schema forward, rollback also needs [`../ops/SOP_ROLLBACK.md`](../ops/SOP_ROLLBACK.md) §5.
+  - If the update was a model name, rollback only needs a config edit + `systemctl restart`.
+
+## 9. Docs updates
+
+- [ ] [`../AGENT_CONTEXT.md`](../AGENT_CONTEXT.md) "Stable facts" — pin bumped.
+- [ ] [`../PRODUCTION_ENVIRONMENT.md`](../PRODUCTION_ENVIRONMENT.md) — infra detail updated if relevant.
+- [ ] [`../ops/SOP_DEPLOY.md`](../ops/SOP_DEPLOY.md) — if the deploy procedure itself changes (rare).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,46 @@
+# scripts/
+
+Operational helpers for the Student-Accessible-Powerpoint project.
+All scripts are **stdlib-only** so they work on any developer / agent machine
+and on the production VM without extra installs.
+
+| Script | What it does | When to run |
+|---|---|---|
+| [`doctor.py`](doctor.py) | Offline environment check: Python version, venv, repo layout, `.env`, git state, disk space. | Right after `git clone`. Whenever "it doesn't work on my machine". |
+| [`check_invariants.py`](check_invariants.py) | Static regex-level guards for the invariants in [`../docs/guardrails/INVARIANTS.md`](../docs/guardrails/INVARIANTS.md). | Before every PR. In CI once CI exists. |
+| [`preflight.py`](preflight.py) | Aggregates `doctor` + `check_invariants` + `pytest` + import smoke. | Before opening a PR. |
+| [`smoke_test.py`](smoke_test.py) | HTTP smoke test against a deployed URL (defaults to prod). | Post-deploy gate; see [`../docs/ops/SOP_DEPLOY.md`](../docs/ops/SOP_DEPLOY.md). |
+
+## Typical flows
+
+**Fresh clone:**
+
+```bash
+python scripts/doctor.py
+```
+
+**Before opening a PR:**
+
+```bash
+python scripts/preflight.py
+```
+
+**After a prod deploy:**
+
+```bash
+python scripts/smoke_test.py --strict
+```
+
+**Debug a single invariant:**
+
+```bash
+python scripts/check_invariants.py --list
+python scripts/check_invariants.py --only order_number alt_text_xml
+```
+
+## Adding a new script
+
+- Keep it stdlib-only unless there's a compelling reason.
+- Print a clear final line with `PASS` / `FAIL`.
+- Return exit code 0 on pass, 1 on hard failure, 2 on usage error.
+- Add it to this README and to [`preflight.py`](preflight.py) if it should gate PRs.

--- a/scripts/check_invariants.py
+++ b/scripts/check_invariants.py
@@ -83,16 +83,26 @@ def check_order_number() -> CheckResult:
 def check_alt_text_xml() -> CheckResult:
     """
     Invariant #2: alt text writes to cNvPr/@descr (native XML).
+
+    Different branches put the rebuild loop in different modules:
+      - main / RAG-integration-branch: app/ppt_notes.py
+      - Aggrement:                      app/pptx_rag_quizzer/pptx.py
+      - Prod-v1:                        may be either of the above
+    Rather than pin a path, scan all of app/ for a line that writes a
+    `descr` attribute onto a cNvPr element. That is the *actual* invariant.
     """
-    target = APP / "ppt_notes.py"
-    txt = _read(target)
-    if not txt:
-        return False, f"cannot read {target}"
-    if "cNvPr" not in txt:
-        return False, "cNvPr not referenced in app/ppt_notes.py — alt text may not be hitting native XML"
-    if "descr" not in txt:
-        return False, "`descr` attribute not referenced — alt text write is incomplete"
-    return True, "cNvPr + descr present in app/ppt_notes.py"
+    pattern = re.compile(r"cNvPr[^\n]{0,120}descr|descr[^\n]{0,120}cNvPr")
+    hits: List[str] = []
+    for py in _walk_py(APP):
+        txt = _read(py)
+        if pattern.search(txt):
+            hits.append(str(py.relative_to(REPO_ROOT)))
+    if not hits:
+        return False, (
+            "no file in app/ writes `descr` onto a cNvPr element. Alt text "
+            "is probably not hitting native PPTX XML. See INVARIANTS.md §2."
+        )
+    return True, f"cNvPr/@descr write found in: {', '.join(hits)}"
 
 
 def check_gemini_rate_limit() -> CheckResult:

--- a/scripts/check_invariants.py
+++ b/scripts/check_invariants.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+check_invariants.py — static guard against regressing project invariants.
+
+Each check is a small regex / file probe that encodes one invariant from
+docs/guardrails/INVARIANTS.md. Run as part of preflight and in CI (once CI
+exists).
+
+Usage:
+    python scripts/check_invariants.py                 # run all
+    python scripts/check_invariants.py --only order_number alt_text_xml
+    python scripts/check_invariants.py --list
+
+Exit code 0 = pass, 1 = at least one invariant failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Callable, Dict, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+APP = REPO_ROOT / "app"
+
+
+# ---------- tiny helper ----------
+
+def _read(p: Path) -> str:
+    try:
+        return p.read_text(encoding="utf-8", errors="replace")
+    except FileNotFoundError:
+        return ""
+
+
+def _walk_py(root: Path) -> List[Path]:
+    return sorted(p for p in root.rglob("*.py") if "venv" not in p.parts)
+
+
+# ---------- checks ----------
+
+CheckResult = Tuple[bool, str]  # (passed, detail)
+
+# Checks marked non-hard produce a WARN (non-zero-ish signal) but don't fail
+# the overall script. Use for pre-existing technical debt we want to
+# surface loudly without blocking every PR.
+NON_HARD = {"groups"}
+
+
+def check_order_number() -> CheckResult:
+    """
+    Invariant #1: order_number is the join key.
+
+    Enforcement strategy:
+      - models.py MUST define order_number (or the invariant is silently dead).
+      - Any file that assigns order_number must use the canonical
+        'order_number=' kw-arg (not a positional) so refactors can grep for it.
+      - At least one caller beyond models.py must reference order_number.
+    """
+    models = APP / "models" / "models.py"
+    if not models.exists():
+        return False, "app/models/models.py missing"
+    models_txt = _read(models)
+    if "order_number" not in models_txt:
+        return False, "models.py does not define 'order_number' — invariant #1 lost"
+
+    callers = 0
+    for py in _walk_py(APP):
+        if py == models:
+            continue
+        if "order_number" in _read(py):
+            callers += 1
+    if callers == 0:
+        return False, (
+            "order_number is defined in models.py but no caller references it. "
+            "Rebuild paths must read it."
+        )
+    return True, f"defined in models.py and referenced in {callers} other file(s)"
+
+
+def check_alt_text_xml() -> CheckResult:
+    """
+    Invariant #2: alt text writes to cNvPr/@descr (native XML).
+    """
+    target = APP / "ppt_notes.py"
+    txt = _read(target)
+    if not txt:
+        return False, f"cannot read {target}"
+    if "cNvPr" not in txt:
+        return False, "cNvPr not referenced in app/ppt_notes.py — alt text may not be hitting native XML"
+    if "descr" not in txt:
+        return False, "`descr` attribute not referenced — alt text write is incomplete"
+    return True, "cNvPr + descr present in app/ppt_notes.py"
+
+
+def check_gemini_rate_limit() -> CheckResult:
+    """
+    Invariant #3: on quota exhaustion, sleep 60 s.
+    """
+    target = APP / "pptx_rag_quizzer" / "rag_core.py"
+    txt = _read(target)
+    if not txt:
+        return False, f"cannot read {target}"
+    has_trigger = "Resource has been exhausted" in txt or "ResourceExhausted" in txt
+    # accept quota_refill_delay = 60 OR direct sleep(60)
+    has_60 = bool(
+        re.search(r"quota_refill_delay\s*=\s*60", txt)
+        or re.search(r"time\.sleep\(\s*60\s*\)", txt)
+    )
+    if not has_trigger:
+        return False, "no 'Resource has been exhausted' / 'ResourceExhausted' handling found"
+    if not has_60:
+        return False, "found trigger but no 60s backoff (quota_refill_delay=60 or time.sleep(60))"
+    return True, "quota-exhausted handler present with 60s backoff"
+
+
+def check_chroma_wrapper() -> CheckResult:
+    """
+    Invariant #4: Chroma access goes through the FastAPI wrapper, not
+    direct chromadb.HttpClient / PersistentClient from Streamlit code.
+    """
+    violations: List[str] = []
+    for py in _walk_py(APP):
+        if py.parts[-2:] == ("chroma-api", "app.py"):
+            continue  # wrapper is allowed to use chromadb directly
+        txt = _read(py)
+        if re.search(r"\bchromadb\.(HttpClient|PersistentClient)\b", txt):
+            violations.append(str(py.relative_to(REPO_ROOT)))
+    if violations:
+        return False, (
+            "chromadb.HttpClient/PersistentClient used outside chroma-api wrapper: "
+            + ", ".join(violations)
+        )
+    return True, "only chroma-api/app.py uses chromadb client directly"
+
+
+def check_image_normalization() -> CheckResult:
+    """
+    Invariant #5: Image normalization (WMF/EMF -> PNG/JPG, 'P'/'RGBA' -> 'RGB')
+    must run before Gemini / hashing. We look for *any* of the well-known
+    markers across the app. This is a soft-intent check; it succeeds if the
+    pipeline demonstrates awareness of the problem.
+
+    Markers (any one counts):
+      - function name convert_image_to_png_or_jpg  (Aggrement branch name)
+      - PIL mode switching: Image.open(...).convert("RGB")
+      - explicit WMF/EMF handling
+      - pytesseract image pre-processing (used on this codebase)
+    """
+    markers = {
+        "convert_image_to_png_or_jpg": r"convert_image_to_png_or_jpg",
+        "PIL .convert('RGB')":         r"\.convert\(\s*['\"]RGB['\"]\s*\)",
+        "WMF/EMF branch":              r"\bWMF\b|\bEMF\b",
+        "Image.open":                  r"Image\.open\(",
+    }
+    hits: Dict[str, int] = {label: 0 for label in markers}
+    for py in _walk_py(APP):
+        txt = _read(py)
+        for label, pattern in markers.items():
+            if re.search(pattern, txt):
+                hits[label] += 1
+    total = sum(hits.values())
+    if total == 0:
+        return False, (
+            "no image-normalization markers found in app/. Expected one of: "
+            "Image.open / .convert('RGB') / WMF-EMF branch / convert_image_to_png_or_jpg."
+        )
+    summary = ", ".join(f"{k}={v}" for k, v in hits.items() if v)
+    return True, f"image pre-processing markers present ({summary})"
+
+
+def check_chroma_not_gitignored_destructively() -> CheckResult:
+    """
+    Invariant #6: don't accidentally wipe prod vector data.
+    Guard: `.gitignore` must not contain a bare `chroma` entry that would
+    match both the in-repo dev dir *and* the prod data dir ambiguously.
+    A more specific path (e.g. '/chroma-db') is fine.
+    """
+    gi = REPO_ROOT / ".gitignore"
+    if not gi.exists():
+        return True, "no .gitignore"  # not a fail; just nothing to check
+    lines = [
+        ln.strip() for ln in gi.read_text(encoding="utf-8", errors="replace").splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    ]
+    bad = [ln for ln in lines if ln in {"chroma", "chroma/", "**/chroma", "**/chroma/"}]
+    if bad:
+        return False, (
+            "ambiguous 'chroma' entry in .gitignore — may wipe prod vector data on git clean. "
+            "Use '/chroma-db' (current pattern) or a more specific path. See INVARIANTS.md §6."
+        )
+    return True, ".gitignore does not contain an ambiguous 'chroma' entry"
+
+
+def check_group_traversal_hint() -> CheckResult:
+    """
+    Invariant #7: group shapes must be traversed recursively. This is hard
+    to verify statically; we check that a hint is present where .shapes is
+    iterated (either MSO_SHAPE_TYPE.GROUP, recursion, or an explicit
+    noqa-style comment).
+    """
+    suspect: List[str] = []
+    for py in _walk_py(APP):
+        txt = _read(py)
+        if not re.search(r"\bslide\.shapes\b|\.shapes\b", txt):
+            continue
+        if (
+            "MSO_SHAPE_TYPE.GROUP" in txt
+            or "is_group" in txt
+            or re.search(r"def\s+_?walk_shapes|recurse_shapes|iter_shapes", txt)
+        ):
+            continue
+        suspect.append(str(py.relative_to(REPO_ROOT)))
+    if suspect:
+        return False, (
+            "files iterate .shapes without any group-handling marker: "
+            + ", ".join(suspect)
+            + ". Confirm group shapes are recursed (invariant #7)."
+        )
+    return True, "all .shapes iterations acknowledge group traversal"
+
+
+def check_secret_not_in_git() -> CheckResult:
+    """
+    Soft invariant: .env, key files, and consent_responses.csv must not
+    be tracked in git.
+    """
+    import subprocess
+    try:
+        res = subprocess.run(
+            ["git", "ls-files"],
+            cwd=REPO_ROOT, capture_output=True, text=True, check=False,
+        )
+        tracked = res.stdout.splitlines()
+    except FileNotFoundError:
+        return False, "git not available"
+    forbidden_exact = {".env", "consent_responses.csv"}
+    forbidden_prefixes = ("chroma/", "chroma-db/", "venv/")
+    hits = [
+        p for p in tracked
+        if p in forbidden_exact or p.startswith(forbidden_prefixes)
+    ]
+    if hits:
+        return False, "forbidden files are tracked: " + ", ".join(hits)
+    return True, "no forbidden files tracked"
+
+
+# ---------- registry ----------
+
+CHECKS: Dict[str, Tuple[str, Callable[[], CheckResult]]] = {
+    "order_number":    ("#1 order_number present where expected", check_order_number),
+    "alt_text_xml":    ("#2 alt text writes cNvPr/@descr", check_alt_text_xml),
+    "gemini_backoff":  ("#3 Gemini 60s quota backoff in rag_core", check_gemini_rate_limit),
+    "chroma_wrapper":  ("#4 chromadb client only inside chroma-api wrapper", check_chroma_wrapper),
+    "image_norm":      ("#5 image normalization path wired", check_image_normalization),
+    "chroma_gitignore":("#6 .gitignore does not ambiguously match chroma/", check_chroma_not_gitignored_destructively),
+    "groups":          ("#7 group-shape traversal acknowledged", check_group_traversal_hint),
+    "secrets":         ("soft: no secret files tracked by git", check_secret_not_in_git),
+}
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Static invariant checks.")
+    p.add_argument("--only", nargs="+", default=None, help="run only these keys")
+    p.add_argument("--list", action="store_true", help="list available checks and exit")
+    args = p.parse_args()
+
+    if args.list:
+        print("Available invariant checks:\n")
+        for key, (desc, _) in CHECKS.items():
+            print(f"  {key:<18}  {desc}")
+        return 0
+
+    keys = args.only if args.only else list(CHECKS.keys())
+    unknown = [k for k in keys if k not in CHECKS]
+    if unknown:
+        print(f"Unknown check(s): {unknown}", file=sys.stderr)
+        return 2
+
+    print(f"check_invariants.py :: running {len(keys)} check(s)\n")
+    hard_failures = 0
+    warnings = 0
+    for key in keys:
+        desc, fn = CHECKS[key]
+        try:
+            passed, detail = fn()
+        except Exception as e:
+            passed, detail = False, f"check raised {type(e).__name__}: {e}"
+        if passed:
+            tag = "OK  "
+        elif key in NON_HARD:
+            tag = "WARN"
+            warnings += 1
+        else:
+            tag = "FAIL"
+            hard_failures += 1
+        print(f"  [{tag}] {key:<18} {desc}")
+        if detail:
+            print(f"         {detail}")
+
+    print()
+    if hard_failures == 0:
+        msg = "check_invariants: all hard checks pass."
+        if warnings:
+            msg += f" ({warnings} warning(s) - known debt, not blocking)"
+        print(msg)
+        return 0
+    print(f"check_invariants: {hard_failures} invariant check(s) failed, {warnings} warning(s).")
+    print("See docs/guardrails/INVARIANTS.md for full context.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""
+doctor.py — fast offline environment sanity check.
+
+Runs on a fresh clone or an existing dev setup and reports whether the
+environment is ready to develop / run the app. stdlib-only; does not hit
+the network.
+
+Exit code 0 = all green. 1 = at least one hard failure.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------- reporting helpers ----------
+
+def _supports_color() -> bool:
+    if not sys.stdout.isatty():
+        return False
+    if os.name == "nt":
+        return "WT_SESSION" in os.environ or os.environ.get("TERM") not in (None, "")
+    return True
+
+
+def _c(s: str, code: str) -> str:
+    if not _supports_color():
+        return s
+    return f"\033[{code}m{s}\033[0m"
+
+
+GREEN = lambda s: _c(s, "32")  # noqa: E731
+RED = lambda s: _c(s, "31")  # noqa: E731
+YELLOW = lambda s: _c(s, "33")  # noqa: E731
+DIM = lambda s: _c(s, "2")  # noqa: E731
+
+
+class Check:
+    def __init__(self, name: str, hard: bool = True):
+        self.name = name
+        self.hard = hard
+        self.passed = False
+        self.detail = ""
+
+    def ok(self, detail: str = "") -> "Check":
+        self.passed = True
+        self.detail = detail
+        return self
+
+    def fail(self, detail: str) -> "Check":
+        self.passed = False
+        self.detail = detail
+        return self
+
+    def render(self) -> str:
+        if self.passed:
+            return f"  {GREEN('[OK]')}    {self.name}" + (
+                f"  {DIM(self.detail)}" if self.detail else ""
+            )
+        tag = RED("[FAIL]") if self.hard else YELLOW("[WARN]")
+        return f"  {tag}  {self.name}\n         {self.detail}"
+
+
+# ---------- checks ----------
+
+def check_python_version() -> Check:
+    c = Check("Python 3.11.x")
+    major, minor = sys.version_info[:2]
+    if major == 3 and minor == 11:
+        return c.ok(f"running {sys.version.split()[0]}")
+    return c.fail(
+        f"prod runs 3.11.2; you are on {major}.{minor}. "
+        "Create a 3.11 venv to match prod ABI."
+    )
+
+
+def check_in_venv() -> Check:
+    c = Check("Running inside a virtualenv", hard=False)
+    in_venv = (
+        hasattr(sys, "real_prefix")
+        or (hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix)
+    )
+    if in_venv:
+        return c.ok(f"prefix={sys.prefix}")
+    return c.fail("not in a venv; install deps into a venv to match prod.")
+
+
+def check_required_tools() -> List[Check]:
+    out = []
+    for tool in ["git", "pip"]:
+        c = Check(f"`{tool}` on PATH")
+        if shutil.which(tool):
+            out.append(c.ok())
+        else:
+            out.append(c.fail(f"{tool} not found on PATH"))
+    return out
+
+
+def check_repo_layout() -> List[Check]:
+    expected_dirs = ["app", "app/pptx_rag_quizzer", "app/models", "app/chroma-api", "docs"]
+    expected_files = [
+        "requirements.txt",
+        "requirements-app.txt",
+        ".env.example",
+        "app/ppt_notes.py",
+        "app/models/models.py",
+        "app/pptx_rag_quizzer/rag_core.py",
+        "app/pptx_rag_quizzer/utils.py",
+        "app/pptx_rag_quizzer/image.py",
+        "app/chroma-api/app.py",
+    ]
+    out = []
+    for d in expected_dirs:
+        c = Check(f"dir exists: {d}")
+        p = REPO_ROOT / d
+        out.append(c.ok() if p.is_dir() else c.fail(f"missing: {p}"))
+    for f in expected_files:
+        c = Check(f"file exists: {f}")
+        p = REPO_ROOT / f
+        out.append(c.ok() if p.is_file() else c.fail(f"missing: {p}"))
+    return out
+
+
+def check_env_file() -> Check:
+    c = Check(".env present with GOOGLE_API_KEY", hard=False)
+    env = REPO_ROOT / ".env"
+    if not env.is_file():
+        return c.fail(
+            "no .env file. Copy .env.example -> .env and paste your GOOGLE_API_KEY."
+        )
+    try:
+        txt = env.read_text(encoding="utf-8", errors="replace")
+    except Exception as e:
+        return c.fail(f"could not read .env: {e}")
+    has_key = any(
+        line.strip().startswith("GOOGLE_API_KEY=") and "=" in line and line.strip().split("=", 1)[1]
+        for line in txt.splitlines()
+    )
+    if not has_key:
+        return c.fail(".env exists but GOOGLE_API_KEY is empty or missing.")
+    return c.ok()
+
+
+def check_not_gitignored_assets() -> List[Check]:
+    """Warn if files that must not be committed already are."""
+    out = []
+    risky = [".env", "chroma", "chroma-db"]
+    try:
+        res = subprocess.run(
+            ["git", "ls-files"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        tracked = set(res.stdout.splitlines())
+    except FileNotFoundError:
+        return [Check("git installed", hard=False).fail("git not on PATH")]
+    for r in risky:
+        c = Check(f"'{r}' is not tracked", hard=True)
+        bad = [p for p in tracked if p == r or p.startswith(r + "/") or p.startswith(r + os.sep)]
+        out.append(c.fail(f"tracked: {bad}") if bad else c.ok())
+    return out
+
+
+def check_disk_space() -> Check:
+    c = Check("at least 500 MB free on repo drive", hard=False)
+    try:
+        usage = shutil.disk_usage(REPO_ROOT)
+        free_mb = usage.free // (1024 * 1024)
+        if free_mb < 500:
+            return c.fail(f"only {free_mb} MB free")
+        return c.ok(f"{free_mb} MB free")
+    except Exception as e:
+        return c.fail(str(e))
+
+
+def check_git_branch_known() -> Check:
+    c = Check("On a known branch", hard=False)
+    try:
+        res = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=REPO_ROOT, capture_output=True, text=True, check=False,
+        )
+        branch = res.stdout.strip()
+        known = {"main", "Aggrement", "Prod-v1", "nextjs-impl", "RAG-integration-branch"}
+        if branch in known:
+            return c.ok(f"on '{branch}'")
+        if branch.startswith(("feat/", "fix/", "chore/", "refactor/", "deps/")):
+            return c.ok(f"on '{branch}' (short-lived)")
+        return c.fail(
+            f"on '{branch}'. See docs/guardrails/BRANCHING.md — use feat/ fix/ chore/ refactor/ deps/."
+        )
+    except Exception as e:
+        return c.fail(str(e))
+
+
+# ---------- entry point ----------
+
+def main() -> int:
+    print(f"doctor.py :: environment check for {REPO_ROOT.name}\n")
+
+    batches: List[Tuple[str, List[Check]]] = [
+        ("Interpreter",        [check_python_version(), check_in_venv()]),
+        ("Tools",              check_required_tools()),
+        ("Repo layout",        check_repo_layout()),
+        ("Config",             [check_env_file()]),
+        ("Safety",             check_not_gitignored_assets()),
+        ("Capacity",           [check_disk_space()]),
+        ("Branch",             [check_git_branch_known()]),
+    ]
+
+    hard_fails = 0
+    for title, checks in batches:
+        print(f"[{title}]")
+        for c in checks:
+            print(c.render())
+            if not c.passed and c.hard:
+                hard_fails += 1
+        print()
+
+    if hard_fails == 0:
+        print(GREEN("doctor: all hard checks pass."))
+        return 0
+    print(RED(f"doctor: {hard_fails} hard check(s) failed."))
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+preflight.py — run before opening a PR.
+
+Aggregates:
+    1. scripts/doctor.py            (environment)
+    2. scripts/check_invariants.py  (static invariants)
+    3. pytest -q                    (unit tests, if any)
+    4. import-smoke of app modules  (catches syntax errors / missing deps)
+
+Any hard failure -> exit code 1.
+Warnings -> exit code 0 but flagged.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "scripts"
+
+
+def run_step(title: str, argv: list[str], *, cwd: Path = REPO_ROOT, required: bool = True) -> int:
+    bar = "=" * 72
+    print(f"\n{bar}\n[preflight] {title}\n{bar}")
+    try:
+        proc = subprocess.run(argv, cwd=cwd)
+    except FileNotFoundError as e:
+        print(f"[preflight] could not run {argv[0]}: {e}")
+        return 1 if required else 0
+    if proc.returncode != 0:
+        print(f"[preflight] step '{title}' exited with code {proc.returncode}")
+    return proc.returncode
+
+
+THIRD_PARTY = {
+    "streamlit", "google", "google.generativeai", "pptx", "PIL",
+    "chromadb", "fastapi", "pydantic", "pytesseract", "requests",
+    "docx", "lxml", "uvicorn",
+}
+
+
+def _is_missing_third_party(exc: BaseException) -> bool:
+    if not isinstance(exc, ModuleNotFoundError):
+        return False
+    missing = getattr(exc, "name", "") or ""
+    return any(missing == t or missing.startswith(t + ".") for t in THIRD_PARTY)
+
+
+def import_smoke() -> int:
+    """
+    Import app modules to catch syntax errors early.
+    Missing third-party deps -> WARN (not FAIL), since a fresh workstation
+    may not yet have `pip install -r requirements.txt`.
+    """
+    print("\n" + "=" * 72)
+    print("[preflight] import smoke test")
+    print("=" * 72)
+    mods = [
+        "app.models.models",
+        "app.pptx_rag_quizzer.rag_core",
+        "app.pptx_rag_quizzer.image",
+        "app.pptx_rag_quizzer.utils",
+    ]
+    failed = []
+    warned = []
+    sys.path.insert(0, str(REPO_ROOT))
+    sys.path.insert(0, str(REPO_ROOT / "app"))  # some modules use top-level imports
+    for m in mods:
+        try:
+            __import__(m)
+            print(f"  OK   import {m}")
+        except SyntaxError as e:
+            print(f"  FAIL import {m}: SyntaxError: {e}")
+            failed.append(m)
+        except ModuleNotFoundError as e:
+            if _is_missing_third_party(e):
+                print(f"  WARN import {m}: third-party dep missing ({e.name}) - run pip install -r requirements.txt")
+                warned.append(m)
+            else:
+                print(f"  FAIL import {m}: ModuleNotFoundError: {e}")
+                failed.append(m)
+        except Exception as e:
+            print(f"  FAIL import {m}: {type(e).__name__}: {e}")
+            failed.append(m)
+
+    if warned:
+        print(f"  ({len(warned)} warning(s) - install deps before pushing)")
+    return 0 if not failed else 1
+
+
+def main() -> int:
+    failures = 0
+
+    # 1. doctor
+    rc = run_step("doctor", [sys.executable, str(SCRIPTS / "doctor.py")], required=True)
+    if rc != 0:
+        failures += 1
+
+    # 2. invariants
+    rc = run_step(
+        "check_invariants",
+        [sys.executable, str(SCRIPTS / "check_invariants.py")],
+        required=True,
+    )
+    if rc != 0:
+        failures += 1
+
+    # 3. pytest (optional - project may have no tests yet, or pytest not installed locally)
+    tests_dir = REPO_ROOT / "tests"
+    has_tests = tests_dir.exists() and any(tests_dir.rglob("test_*.py"))
+    if has_tests:
+        try:
+            import pytest  # noqa: F401
+            rc = run_step("pytest", [sys.executable, "-m", "pytest", "-q"], required=True)
+            if rc != 0:
+                failures += 1
+        except ImportError:
+            print("\n[preflight] pytest not installed - skipping (WARN).")
+            print("           `pip install pytest` and re-run, or rely on CI.")
+    else:
+        print("\n[preflight] no tests/ directory with test_*.py - skipping pytest.")
+        print("           Add a test with every change. See CONTRIBUTING.md section 5.")
+
+    # 4. import smoke
+    rc = import_smoke()
+    if rc != 0:
+        failures += 1
+
+    print("\n" + "=" * 72)
+    if failures == 0:
+        print("[preflight] PASS - you are clear to open a PR.")
+        print("            Fill the matching template from docs/templates/ in the PR body.")
+        return 0
+    print(f"[preflight] FAIL - {failures} step(s) failed. Fix before opening a PR.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke_test.py
+++ b/scripts/smoke_test.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+smoke_test.py — HTTP-level smoke test for the deployed Streamlit app.
+
+Intended as the post-deploy gate in docs/ops/SOP_DEPLOY.md. stdlib-only so
+it can be run from any workstation without installing anything.
+
+Usage:
+    python scripts/smoke_test.py
+    python scripts/smoke_test.py --url https://access.brockportsigai.org/accessibility
+    python scripts/smoke_test.py --url http://localhost:8501 --local
+
+Checks performed:
+    1. HTTPS reachable, status 200 (or allowed redirect chain) within timeout.
+    2. Response includes the Streamlit HTML shell.
+    3. `/` (the landing page at host root) returns 200 with a Brockport/SIGAI title.
+    4. (--strict) the internal FastAPI wrapper is NOT publicly reachable.
+    5. (--strict) the Streamlit port is NOT publicly reachable *except* via nginx.
+
+Exit code 0 = all green; 1 = at least one hard failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import socket
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import List, Optional
+from urllib.parse import urlparse
+
+DEFAULT_URL = "https://access.brockportsigai.org/accessibility"
+TIMEOUT = 15  # seconds
+USER_AGENT = "student-access-ppt-smoke/1.0 (+docs/ops/SOP_DEPLOY.md)"
+
+
+# ---------- result type ----------
+
+@dataclass
+class Result:
+    name: str
+    passed: bool
+    detail: str
+    hard: bool = True
+
+
+def _get(url: str, timeout: int = TIMEOUT) -> tuple[int, str, dict]:
+    """GET a URL; return (status, body, headers). Raises on transport failure."""
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    ctx = ssl.create_default_context()
+    with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+        body = resp.read().decode("utf-8", errors="replace")
+        return resp.status, body, dict(resp.headers)
+
+
+def _try_connect(host: str, port: int, timeout: float = 5.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+# ---------- checks ----------
+
+def check_reachable(url: str) -> Result:
+    try:
+        status, body, _ = _get(url)
+    except urllib.error.HTTPError as e:
+        return Result("reachable (HTTP)", False, f"HTTP {e.code} {e.reason}")
+    except urllib.error.URLError as e:
+        return Result("reachable (HTTP)", False, f"URL error: {e.reason}")
+    except socket.timeout:
+        return Result("reachable (HTTP)", False, f"timeout after {TIMEOUT}s")
+    except Exception as e:
+        return Result("reachable (HTTP)", False, f"{type(e).__name__}: {e}")
+    if status != 200:
+        return Result("reachable (HTTP)", False, f"status={status}")
+    return Result("reachable (HTTP)", True, f"200 OK, {len(body)} bytes")
+
+
+def check_streamlit_shell(url: str) -> Result:
+    try:
+        _, body, _ = _get(url)
+    except Exception as e:
+        return Result("streamlit shell present", False, f"fetch failed: {e}")
+    # Streamlit serves a bootstrap HTML that references 'stApp' and the
+    # websocket endpoint. We look for a couple of stable markers.
+    markers = ["<title>", "streamlit", "stApp"]
+    missing = [m for m in markers if m.lower() not in body.lower()]
+    if missing:
+        return Result(
+            "streamlit shell present", False, f"missing markers: {missing}",
+        )
+    return Result("streamlit shell present", True, f"markers ok ({', '.join(markers)})")
+
+
+def check_landing(url: str) -> Result:
+    """If URL is host/accessibility, also probe host root for the landing page."""
+    p = urlparse(url)
+    if not p.scheme or not p.netloc:
+        return Result("landing page (/)", False, "cannot derive host from URL", hard=False)
+    root = f"{p.scheme}://{p.netloc}/"
+    try:
+        status, body, _ = _get(root)
+    except Exception as e:
+        return Result("landing page (/)", False, f"fetch failed: {e}", hard=False)
+    if status != 200:
+        return Result("landing page (/)", False, f"status={status}", hard=False)
+    if not body.strip():
+        return Result("landing page (/)", False, "empty body", hard=False)
+    return Result("landing page (/)", True, f"200 OK, {len(body)} bytes")
+
+
+def check_port_not_public(host: str, port: int, label: str) -> Result:
+    """In strict mode, the internal port should NOT be publicly reachable."""
+    is_open = _try_connect(host, port, timeout=4.0)
+    if is_open:
+        return Result(
+            f"port {port} ({label}) not public",
+            False,
+            f"{host}:{port} is reachable from the public internet — "
+            "review docs/guardrails/INVARIANTS.md §10.4 and GCP firewall.",
+            hard=False,  # warn, don't fail — this is a known prod drift
+        )
+    return Result(f"port {port} ({label}) not public", True, "not reachable externally")
+
+
+# ---------- runner ----------
+
+def run(url: str, strict: bool, local: bool) -> int:
+    print(f"smoke_test.py :: target={url} strict={strict} local={local}\n")
+    results: List[Result] = []
+    results.append(check_reachable(url))
+    if results[-1].passed:
+        results.append(check_streamlit_shell(url))
+    else:
+        results.append(Result("streamlit shell present", False, "skipped (unreachable)"))
+
+    results.append(check_landing(url))
+
+    if strict and not local:
+        p = urlparse(url)
+        host = p.hostname or ""
+        if host:
+            # The prod firewall currently exposes these publicly; the check
+            # flags the leak but does not hard-fail by default.
+            results.append(check_port_not_public(host, 8501, "Streamlit direct"))
+            results.append(check_port_not_public(host, 8001, "chroma-api"))
+
+    print("Results:")
+    fails = 0
+    warns = 0
+    for r in results:
+        if r.passed:
+            tag = "[OK]  "
+        else:
+            tag = "[FAIL]" if r.hard else "[WARN]"
+            if r.hard:
+                fails += 1
+            else:
+                warns += 1
+        print(f"  {tag} {r.name:<32} {r.detail}")
+
+    print()
+    if fails == 0:
+        print(f"smoke_test: PASS ({warns} warning(s))" if warns else "smoke_test: PASS")
+        return 0
+    print(f"smoke_test: FAIL ({fails} hard failure(s), {warns} warning(s))")
+    print("Run docs/ops/SOP_ROLLBACK.md if this was a post-deploy check.")
+    return 1
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="HTTP smoke test for deployed app.")
+    p.add_argument("--url", default=DEFAULT_URL)
+    p.add_argument("--strict", action="store_true", help="also check for exposure of internal ports")
+    p.add_argument("--local", action="store_true", help="target a local dev URL; skip public-exposure checks")
+    args = p.parse_args()
+    return run(args.url, args.strict, args.local)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,36 @@
+# tests/
+
+Test suite for Student-Accessible-Powerpoint.
+
+## Running
+
+```bash
+python -m pytest -q
+```
+
+Preflight (`scripts/preflight.py`) runs this automatically if any `test_*.py`
+files exist.
+
+## Policy
+
+- Every PR adds at least one test for the code it changes, or explicitly
+  justifies "N/A" in the PR description. See
+  [`../CONTRIBUTING.md`](../CONTRIBUTING.md) section 5.
+- Prefer fast, offline, stdlib + pytest tests. No network calls to Gemini
+  or production ChromaDB from the test suite.
+- When you need to exercise an invariant from
+  [`../docs/guardrails/INVARIANTS.md`](../docs/guardrails/INVARIANTS.md),
+  mirror the check in `scripts/check_invariants.py` if possible so CI can
+  enforce it without pytest.
+
+## Layout
+
+```
+tests/
+  conftest.py          # shared fixtures (add as needed)
+  test_invariants.py   # re-runs scripts/check_invariants.py as a pytest
+  test_models.py       # Pydantic model smoke tests
+  ...
+```
+
+New test files must follow `test_*.py`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""
+Shared pytest configuration.
+
+Adds repo root and app/ to sys.path so tests can import both
+`app.models.models` style and direct `models.models` style
+(the app uses both depending on branch).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(REPO_ROOT / "app"))

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -1,0 +1,30 @@
+"""
+Bridge between pytest and scripts/check_invariants.py.
+
+Runs the invariant script as a pytest so the full preflight gate is green
+or red under a single command.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check_invariants.py"
+
+
+def test_invariants_script_passes():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            "check_invariants.py reported hard failures:\n"
+            + result.stdout
+            + "\n---\n"
+            + result.stderr
+        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,79 @@
+"""
+Smoke tests for the Pydantic data model.
+
+These guard invariant #1 (order_number exists and is an int) at the type
+level, so a reckless rename of the field fails a test rather than silently
+misalignining alt text at runtime.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_slide_item_requires_order_number():
+    from models.models import Text, Type
+
+    with pytest.raises(Exception):
+        # order_number intentionally omitted; pydantic must reject this.
+        Text(id="1", slide_number=1, content="hi", type=Type.text)
+
+
+def test_slide_item_order_number_is_int():
+    from models.models import Text, Type
+
+    with pytest.raises(Exception):
+        Text(
+            id="1",
+            slide_number=1,
+            content="hi",
+            type=Type.text,
+            order_number="not-an-int",  # type: ignore[arg-type]
+        )
+
+
+def test_image_carries_bytes_and_extension():
+    from models.models import Image, Type
+
+    img = Image(
+        id="i1",
+        slide_number=1,
+        content="",
+        type=Type.image,
+        order_number=0,
+        image_bytes=b"\x89PNG\r\n",
+        extension="png",
+    )
+    md = img.metadata()
+    # metadata must preserve order_number for the join invariant.
+    assert md["order_number"] == 0
+    assert md["slide_number"] == 1
+    assert md["type"] == "image"
+
+
+def test_presentation_slide_item_union_roundtrip():
+    from models.models import Image, Presentation, Slide, Text, Type
+
+    deck = Presentation(
+        id="p1",
+        name="deck.pptx",
+        slides=[
+            Slide(
+                id="s1",
+                slide_number=1,
+                items=[
+                    Text(id="t1", slide_number=1, content="hello", type=Type.text, order_number=0),
+                    Image(
+                        id="i1",
+                        slide_number=1,
+                        content="",
+                        type=Type.image,
+                        order_number=1,
+                        image_bytes=b"x",
+                        extension="png",
+                    ),
+                ],
+            )
+        ],
+    )
+    assert [it.order_number for it in deck.slides[0].items] == [0, 1]


### PR DESCRIPTION
Establish a standard workflow for Features, Updates, Bug Fixes, and Refactors so future agents and developers can change this project safely without breaking local or production environments.

Context docs (previously uncommitted):
- docs/PROJECT_OVERVIEW.md      human narrative of the project
- docs/AGENT_CONTEXT.md         dense tech reference for AI agents
- docs/PRODUCTION_ENVIRONMENT.md  live GCP deployment map

New entry points:
- AGENTS.md         agent-first routing, reading order, hard invariants
- CONTRIBUTING.md   human onboarding, setup, change flow, style
- docs/README.md    index of the whole documentation tree

Architectural guardrails (docs/guardrails/):
- INVARIANTS.md        11 invariants (order_number, cNvPr/@descr, Gemini
                       60s backoff, Chroma-via-FastAPI wrapper, image
                       normalization, chroma/ data safety, group
                       traversal, consent gate, branch discipline,
                       config-of-record), each with a Check command
- BRANCHING.md         roles of main / Aggrement / Prod-v1 /
                       nextjs-impl; cherry-pick flow; protected-branch
                       policy
- CHANGE_CHECKLIST.md  pre-merge checklist pasted into every PR

Standard Operating Procedures (docs/ops/):
- SOP_DEPLOY.md    safe manual deploy to the GCP prod VM, including the
                   pre-deploy drift-stash ritual for the known
                   uncommitted edits on the VM
- SOP_ROLLBACK.md  git/venv/Chroma/nginx/systemd rollback flows
- SOP_INCIDENT.md  symptom matrix + response playbooks (VM down, 502,
                   Gemini quota, TLS, code bug fingerprints including
                   the chromadbapi.sh typo)
- SOP_SECRETS.md   GOOGLE_API_KEY rotation, new-secret onboarding, leak
                   response
- DEPLOY_LOG.md / INCIDENT_LOG.md / SECRET_ROTATION_LOG.md   append-only
                   logs

Agent-optimized change templates (docs/templates/):
- FEATURE.md / UPDATE.md / BUG.md / REFACTOR.md Each template forces the author to declare target branch, invariants touched, accessibility impact, rollback plan, and docs updates.

Operational scripts (scripts/, stdlib-only):
- doctor.py            offline environment sanity check
- check_invariants.py  static regex-level guard for the 8 code-level
                       invariants; supports --list / --only
- preflight.py         aggregates doctor + invariants + pytest + import
                       smoke; graceful on missing third-party deps
- smoke_test.py        HTTP post-deploy gate; supports --strict to warn
                       on public exposure of internal ports

Test scaffold (tests/):
- conftest.py adds app/ to sys.path
- test_models.py guards order_number type-level invariant
- test_invariants.py bridges scripts/check_invariants.py into pytest

GitHub integration (.github/):
- PULL_REQUEST_TEMPLATE.md forces template selection + full checklist
- ISSUE_TEMPLATE/ structured forms for feature / bug / update / refactor
- workflows/preflight.yml runs the exact local gate on every PR and push to main/Aggrement/Prod-v1 (closes the "no CI/CD" gap)
- CODEOWNERS routes reviews

All scripts exit 0 on the current tree; the groups-traversal warning is pre-existing technical debt and surfaces as WARN (non-blocking).

Made-with: Cursor