### PR TITLE
Add Next.js migration planning docs

### DIFF
--- a/docs/refactor/NEXTJS_MIGRATION_DESIGN.md
+++ b/docs/refactor/NEXTJS_MIGRATION_DESIGN.md
@@ -1,0 +1,782 @@
+# Next.js Migration — Design
+
+> **Status:** Finalized technical design, derived from explicit architectural decisions made against [`NEXTJS_MIGRATION_PREFLIGHT.md`](./NEXTJS_MIGRATION_PREFLIGHT.md). This document is the **binding blueprint** for the refactor on branch `refactor/nextjs-migration`.
+>
+> **Institutional / operational items that require external sign-off** are marked **[PENDING MANUAL CONFIRMATION]**. These do not block technical work; they block cutover.
+>
+> **Invariants of record:** [`docs/guardrails/INVARIANTS.md`](../guardrails/INVARIANTS.md). Every design choice below is justified against those invariants; none are relaxed.
+
+---
+
+## 0. Executive Summary
+
+We are splitting the monolithic Python + Streamlit app into a two-tier system:
+
+- **Tier 1 — Next.js 16 App Router on Vercel.** Owns all UI, routing, auth, consent enforcement, job state, DB access, and file upload surface. Stateless compute.
+- **Tier 2 — Python FastAPI sidecar + ChromaDB on the existing GCP VM via Docker Compose.** Owns PPTX parsing, OOXML rebuild (including the `cNvPr/@descr` write), Gemini calls, and Chroma access. All legacy Python invariants live here unchanged.
+
+Supabase provides **auth, Postgres, and blob storage**. Prisma is the ORM. Jobs run asynchronously: Next.js inserts a `Job` row, fires one HTTP call to the Python sidecar to start work, and the client polls a Next.js route handler that reads job status from Postgres. No background workers and no queue in Next.js — the Python service is the worker.
+
+Caddy (from `Prod-v1`) continues to terminate TLS on the VM, but only in front of the FastAPI endpoint, not a UI. The Streamlit `web` service and all `systemd` units are retired at cutover.
+
+### One-diagram view
+
+```
+          ┌─────────────────────────────┐
+  user ──▶│   Vercel: Next.js (App Rtr) │◀──── Supabase Auth (JWT)
+          │   RSC + Client + Route Hdrs │
+          └───────┬──────────────┬──────┘
+                  │              │
+         Prisma   │              │  HTTPS (mTLS/shared-secret)
+                  ▼              ▼
+        ┌────────────────┐  ┌──────────────────────────┐
+        │ Supabase:      │  │ GCP VM (Docker Compose)  │
+        │  - Postgres    │  │  caddy  ──▶  chroma-api  │
+        │  - Storage     │  │              (FastAPI,   │
+        │  - Auth        │  │               parse,     │
+        └────────────────┘  │               rebuild,   │
+                            │               Gemini)    │
+                            │              └──▶ chroma │
+                            │                  (vector)│
+                            └──────────────────────────┘
+```
+
+No component of this diagram violates any invariant; §16 of this document maps each invariant to its owner.
+
+---
+
+## 1. Scope & End-State (resolves preflight §1)
+
+| # | Preflight question | Decision |
+|---|---|---|
+| 1.1 | Replacement or coexist? | **Replacement.** Vercel deployment will own the public domain after cutover. |
+| 1.2 | Which branch is behavior truth? | **`Aggrement`** (the live one), including the IRB consent flow. |
+| 1.3 | Feature freeze on Streamlit? | **[PENDING MANUAL CONFIRMATION]** — owner and exact freeze date. |
+| 1.4 | Node-only or keep FastAPI? | **Keep FastAPI** on the VM; Next.js never touches PPTX or Chroma directly. |
+| 1.5 | KPIs? | Minimum: upload-to-download wall time, Gemini cost/deck, p95 page TTI, 5xx rate. Baseline measurements against live Streamlit **[PENDING]**. |
+| 1.6 | Streamlit sunset policy? | Freeze Streamlit post-cutover for 30 days (read-only on a non-public port), then uninstall the systemd units. See §14. |
+
+**[PENDING MANUAL CONFIRMATION]:** hard feature-freeze date on `Aggrement`; DNS cutover date; whether Streamlit stays reachable on a private port during the 30-day window.
+
+---
+
+## 2. UI & Routing (resolves preflight §2)
+
+### 2.1 Route map (App Router)
+
+All routes under `src/app/` in the Next.js repo.
+
+| Path | Kind | Stage | Notes |
+|---|---|---|---|
+| `/` | RSC | Landing | Marketing shell, static. |
+| `/auth/sign-in`, `/auth/callback` | Client + RSC | — | Supabase Auth UI. |
+| `/consent` | RSC + Server Action | Consent gate | Rendered when `profile.consent_accepted_at IS NULL`. Server Action writes the flag. |
+| `/upload` | RSC shell + Client dropzone | Stage 1 | `POST /api/uploads` streams the file to Supabase Storage, creates a `Job` row, returns `jobId`. |
+| `/process/[jobId]` | RSC | Stage 2 | Reads `Job` from Postgres. Streams status via React `<Suspense>` + client polling component. Redirects to `/review/[jobId]` when `status='awaiting_review'`. |
+| `/review/[jobId]` | RSC shell + Client review grid | Stage 3 | Paginated per-image review with optimistic updates via Server Actions. |
+| `/download/[jobId]` | RSC | Stage 4 | Generates a Supabase Storage signed URL for the rebuilt deck, renders a download button. |
+| `/api/uploads` | Route Handler, Node runtime | — | Streams `multipart/form-data` → Supabase Storage, inserts `Job`, POSTs to Python. |
+| `/api/jobs/[id]` | Route Handler, Node runtime | — | Polling endpoint. Reads Postgres only. |
+| `/api/jobs/[id]/descriptions` | Route Handler, Node runtime | — | Bulk read of per-image descriptions for the review UI. |
+| `/api/webhooks/processor` | Route Handler, Node runtime | — | Called by the Python sidecar to push phase transitions. Protected by a shared secret (§11.4). |
+
+The App Router's segmented routes map 1:1 to the Streamlit `processing_stage` enum. Back-button and reload behavior fall out naturally because stage lives in the URL.
+
+### 2.2 RSC vs Client split (the architectural bet)
+
+| Surface | RSC boundary | Client boundary |
+|---|---|---|
+| Landing, auth shells, consent, upload, process, download | Entire page shell, all data fetches | A single `<Dropzone />` on `/upload`, a single `<StatusPoller jobId=... />` on `/process/[jobId]`, a single `<DownloadButton />` on `/download/[jobId]`. |
+| `/review/[jobId]` | Page shell, initial batch of descriptions (server-fetched from Postgres) | `<ReviewGrid>`, `<ImageCard>`, `<AltTextEditor>` — interactive editors with optimistic UI. Server Actions write back to Postgres. |
+
+**Rules that govern the split** (all enforced in code review):
+
+- RSC is the default. `'use client'` is only added to a component that needs local state, refs, or browser event handlers.
+- No Gemini key, no Supabase service-role key, and no FastAPI shared secret ever appears in a client component or in any RSC that returns props to a client component.
+- Route Handlers only ever run on the **Node runtime**. No Edge runtime anywhere (Gemini SDK needs Node; `adm-zip`-style libraries are not in scope but the policy stays).
+- Server Actions are used for write paths where the response body is trivial (alt-text edits, consent acceptance). Route Handlers are used for reads that the client polls and for the webhook from Python.
+
+### 2.3 Progress UX
+
+- Client polls `GET /api/jobs/[id]` every **2 s** with exponential back-off to 10 s after 2 min.
+- Optional upgrade: replace polling with Supabase Postgres Changes (WebSocket-driven row subscriptions) once the base path is stable. **Post-v1.**
+
+### 2.4 Existing `nextjs-impl` scaffold disposition
+
+The current prototype at `nextjs-impl` is **reference only**. This design deliberately does **not** build on:
+- its single-page client-only `page.tsx`,
+- its stubbed `src/lib/pptx-utils.ts` (violates invariants #1, #2, #5, #7 by omission),
+- its `src/lib/gemini.ts` (no 60 s backoff — violates invariant #3).
+
+We do carry forward:
+- `package.json`'s Next.js 16.2.3 / React 19.2.4 pinning.
+- Tailwind 4 + the `lucide-react` / `framer-motion` UI direction, provided the final palette clears WCAG AA contrast (§15.5).
+- The `backups/python-legacy/` archival pattern — once `refactor/nextjs-migration` lands, the Streamlit code is moved there.
+
+---
+
+## 3. Backend Surface (resolves preflight §3)
+
+### 3.1 Python FastAPI sidecar — expanded responsibilities
+
+The sidecar currently at `app/chroma-api/app.py` is renamed in intent to **"processing service"** and gains job-orchestration endpoints. The existing Chroma CRUD endpoints stay untouched (invariant #4). No Python logic moves to TypeScript.
+
+New endpoints (to be implemented on this branch when the code-freeze unlocks):
+
+| Verb + Path | Purpose | Auth | Body |
+|---|---|---|---|
+| `POST /jobs/:id/start` | Begin processing for a job. Called by Next.js after an upload finishes. | Shared secret header | `{ storage_object: string, presentation_name: string }` |
+| `POST /jobs/:id/commit` | Client finished review. Rebuild the deck and upload to Supabase Storage. | Shared secret header | `{ descriptions: [{ order_number, alt_text }] }` |
+| `GET  /jobs/:id/status` | Mirror of Postgres status. Used only by health checks and debug. | Shared secret header | — |
+| `POST /jobs/:id/cancel` | Abort and cleanup. | Shared secret header | — |
+
+All new endpoints emit a webhook POST to `${NEXT_PUBLIC_APP_URL}/api/webhooks/processor` on each phase transition (`parsed`, `described`, `awaiting_review`, `rebuilding`, `ready`, `error`) so Postgres stays authoritative for status.
+
+The existing endpoints (`/collections`, `/collections/*/add`, `/collections/*/query`, `/health`) are preserved verbatim. Invariant #4 holds: Next.js talks to Chroma only through this service.
+
+### 3.2 Python module boundaries — preserved
+
+All existing modules stay in place and keep their invariants:
+
+| Module | Preserved responsibility | Invariant owned |
+|---|---|---|
+| `app/pptx_rag_quizzer/utils.py :: parse_powerpoint` | Extract text/images; set `order_number` | #1, #7 |
+| `app/ppt_notes.py :: process_powerpoint_with_rag_enhanced` (or its `Aggrement`-branch analog in `app/pptx_rag_quizzer/pptx.py`) | OOXML rebuild; `cNvPr/@descr` write | #2 |
+| `app/pptx_rag_quizzer/rag_core.py :: RAGCore` | Gemini calls with 60 s backoff; Chroma add/query via HTTP wrapper | #3, #4 |
+| `app/pptx_rag_quizzer/image.py :: ImageProcessor` | 4-stage describe pipeline; image normalization | #5 |
+| `app/chroma-api/app.py` | FastAPI; wraps Chroma | #4 |
+
+A small module is added for the new surface:
+
+- `app/processing_service/jobs.py` — implements the `/jobs/*` endpoints. Its only job is orchestration: pull the blob from Supabase Storage via a signed URL, call the existing modules, push results back. It writes **nothing** OOXML-adjacent itself.
+
+### 3.3 Error contract (wire)
+
+Both the Next.js route handlers and the Python endpoints return a uniform shape:
+
+```json
+{ "ok": true, "data": { ... } }
+{ "ok": false, "error": { "code": "GEMINI_QUOTA", "message": "...", "retryable": true } }
+```
+
+Error codes are enumerated (`UPLOAD_TOO_LARGE`, `CONSENT_REQUIRED`, `GEMINI_QUOTA`, `GEMINI_FAILED`, `PARSE_FAILED`, `REBUILD_FAILED`, `CHROMA_UNAVAILABLE`, `JOB_NOT_FOUND`, `UNAUTHORIZED`). The Python side maps existing `Resource has been exhausted` strings to `GEMINI_QUOTA` while still honoring the 60 s backoff internally (invariant #3).
+
+### 3.4 Runtime constraints — written down
+
+- All Next.js Route Handlers: **Node runtime only**. Never Edge.
+- All Server Actions that touch Supabase service-role, the FastAPI shared secret, or signed-URL generation: **Node runtime only**.
+- No TypeScript code imports anything that talks to Chroma or parses `.pptx`. Enforced by a new invariant check (§16.4).
+
+---
+
+## 4. PPTX Parsing & Rebuild (resolves preflight §4)
+
+**Decision:** PPTX parsing, OOXML tree traversal, and rebuild stay in Python. TypeScript never opens a `.pptx`.
+
+This collapses all of preflight §4 into a short statement:
+
+- `parse_powerpoint` unchanged.
+- The `cNvPr/@descr` writer (invariant #2) unchanged.
+- `convert_image_to_png_or_jpg` and WMF/EMF handling (invariant #5) unchanged.
+- Group-shape recursion (invariant #7) unchanged.
+- `python-pptx` stays the parser of record.
+
+The Next.js side's only responsibility for a deck is to move its bytes to Supabase Storage and hand the Python side a reference.
+
+> Consequence: `nextjs-impl/src/lib/pptx-utils.ts` is deleted on this branch and not replaced. Any future PR that introduces TS-side OOXML code must pass through a guardrail PR that relaxes this decision explicitly.
+
+---
+
+## 5. RAG Pipeline (resolves preflight §5)
+
+**Decision:** Gemini and Chroma stay in Python. Invariants #3, #4, #5 are preserved without translation. No JavaScript Gemini or Chroma client is introduced.
+
+| Preflight concern | Resolution |
+|---|---|
+| Gemini client choice | Stays `google.generativeai` (Python). |
+| 60 s backoff | Stays in `rag_core.py`. |
+| `GOOGLE_API_KEY` location | Docker Compose env var on the VM (injected from `.env` on the host; upgrade path to GCP Secret Manager is §11.6). **Never** present in the Vercel environment. |
+| `ImageProcessor.context_cache` (TTL 3600s) | Stays per-process in the Python container. Same behavior as today. Post-v1 upgrade to Redis is possible; not required. |
+| OCR (`ExtractText_OCR`) | Already a placeholder on `main`. Stays a placeholder. Explicit regression accepted. |
+| Lambda Index | Unchanged. |
+| Prompt wording | Frozen exactly as on `Aggrement` branch at cutover. **[PENDING MANUAL CONFIRMATION]** for the owner of prompt changes going forward. |
+| Per-user Gemini cost cap | Enforced in Next.js Route Handler before `/jobs/:id/start` is called: per-user rate-limit row in Postgres. Concrete numbers **[PENDING]**. |
+
+---
+
+## 6. State, Auth, Database (resolves preflight §6 and §10)
+
+### 6.1 Supabase project layout
+
+Supabase gives us three primitives used here:
+
+- **Auth** — email + magic link (optionally SUNY SSO later). Issues a JWT that both Next.js and (optionally) the Python sidecar can verify. For v1 only Next.js verifies; Python trusts the shared-secret header.
+- **Postgres** — app database. Accessed from Next.js via Prisma only. The Python sidecar does **not** read or write Postgres directly; it talks to Next.js webhooks instead. This keeps schema ownership in one place.
+- **Storage** — two buckets:
+  - `pptx-uploads` (private) — raw uploads. Lifecycle rule deletes after N days (see §6.4).
+  - `pptx-outputs` (private) — rebuilt accessible decks. Same lifecycle.
+
+### 6.2 Prisma schema (authoritative)
+
+Filename `prisma/schema.prisma`. Generated types live under `src/lib/db`. No migration is applied by this document; the schema here is the agreement.
+
+```prisma
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")        // Supabase pooled connection
+  directUrl = env("DIRECT_URL")         // Supabase direct (migrations)
+}
+
+/// One row per authenticated user. Mirrors Supabase auth.users.id.
+model Profile {
+  id                     String   @id            // == auth.users.id (uuid)
+  email                  String   @unique
+  consentAcceptedAt      DateTime?               // invariant #8 anchor
+  consentVersion         String?                 // e.g. "v1-2026-04"
+  createdAt              DateTime @default(now())
+  jobs                   Job[]
+  consentEvents          ConsentEvent[]
+}
+
+/// One row per deck upload.
+model Job {
+  id                     String      @id @default(uuid())
+  profileId              String
+  profile                Profile     @relation(fields: [profileId], references: [id])
+
+  uploadedFilename       String
+  uploadObjectPath       String      // key in 'pptx-uploads' bucket
+  outputObjectPath       String?     // key in 'pptx-outputs' bucket, null until ready
+
+  status                 JobStatus   @default(queued)
+  phase                  String?     // human-readable: "parsing" / "describing" / "rebuilding"
+  progressCurrent        Int         @default(0)
+  progressTotal          Int         @default(0)
+  errorCode              String?
+  errorMessage           String?
+
+  collectionId           String?     // Chroma collection id owned by the Python side
+  schemaVersion          Int         @default(1)
+
+  createdAt              DateTime    @default(now())
+  startedAt              DateTime?
+  awaitingReviewAt       DateTime?
+  committedAt            DateTime?
+  readyAt                DateTime?
+
+  descriptions           SlideDescription[]
+
+  @@index([profileId, createdAt])
+}
+
+enum JobStatus {
+  queued
+  parsing
+  describing
+  awaiting_review
+  rebuilding
+  ready
+  error
+  cancelled
+}
+
+/// One row per reviewable image in a deck. `orderNumber` is the invariant-#1 join key.
+model SlideDescription {
+  id                     String   @id @default(uuid())
+  jobId                  String
+  job                    Job      @relation(fields: [jobId], references: [id], onDelete: Cascade)
+
+  slideNumber            Int
+  orderNumber            Int      // invariant #1 — must match python-pptx shape order
+  itemType               String   // "image" | "text" (text is read-only, images are editable)
+  aiDescription          String?  // Gemini-generated
+  finalAltText           String?  // user-edited; this is what gets written to cNvPr/@descr
+
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
+
+  @@unique([jobId, slideNumber, orderNumber])
+  @@index([jobId])
+}
+
+/// Append-only IRB audit trail. Duplicates some Profile data on purpose.
+model ConsentEvent {
+  id                     String   @id @default(uuid())
+  profileId              String
+  profile                Profile  @relation(fields: [profileId], references: [id])
+  acceptedAt             DateTime @default(now())
+  consentVersion         String
+  ipHash                 String                     // SHA-256(ip + pepper)
+  userAgent              String?
+}
+```
+
+### 6.3 Session & state mapping
+
+Every Streamlit `st.session_state` key from preflight §6 has a new home:
+
+| `st.session_state` key | New home |
+|---|---|
+| `processing_stage` | URL segment (`/upload`, `/process/[id]`, `/review/[id]`, `/download/[id]`). |
+| `presentation_model` | Not held in Next.js at all. Lives as rows in `SlideDescription` + the object in `pptx-uploads`. |
+| `rag_core`, `image_processor` | Per-request in the Python container. Unchanged. |
+| `collection_id` | `Job.collectionId`. |
+| `current_batch`, `batch_size` | Query-string params on `/review/[id]?page=N`. |
+| `uploaded_file_name`, `file_bytes` | `Job.uploadedFilename`, `Job.uploadObjectPath`. Never in Node memory past the stream. |
+| `output_path` | `Job.outputObjectPath` (→ signed URL at download time). |
+
+### 6.4 Retention — **[PENDING MANUAL CONFIRMATION]**
+
+Defaults proposed for approval:
+
+- Uploads bucket: **30 days**, then hard delete.
+- Outputs bucket: **30 days**, then hard delete.
+- Chroma collections on the VM: **30 days**, swept by a cron inside the chroma-api container.
+- `Job` and `SlideDescription` rows: retained indefinitely (no PII); linked blobs are gone after 30 days.
+- `ConsentEvent` rows: retained per IRB policy — **[PENDING]** exact horizon.
+
+---
+
+## 7. Long-Running Work (resolves preflight §7)
+
+### 7.1 Async job model
+
+```
+Client ──POST /api/uploads (multipart)──▶ Next.js Route Handler
+                                            │
+                                            ├─ stream body → Supabase Storage (resumable)
+                                            ├─ INSERT Job(status=queued)
+                                            └─ POST  $PY_SERVICE_URL/jobs/{id}/start
+                                                │
+                                                └─ 202 Accepted, returns { jobId }
+Client ──redirect /process/[jobId]─▶
+
+Python sidecar (background asyncio task per request):
+    parse → describe (Gemini) → chroma.add → webhook status=awaiting_review
+
+Client polls GET /api/jobs/[id] every 2–10s → redirect /review/[jobId] when ready.
+
+User reviews, clicks "Confirm & Export":
+Client ──POST /api/jobs/[id]/commit──▶ Next.js Route Handler
+                                        │
+                                        ├─ UPDATE SlideDescription.finalAltText
+                                        └─ POST $PY_SERVICE_URL/jobs/{id}/commit
+                                                │
+                                                └─ rebuild deck → upload to Supabase
+                                                └─ webhook status=ready
+
+Client polls until ready → redirect /download/[jobId] → signed URL.
+```
+
+Key consequences:
+
+- **No Vercel timeout risk.** Route Handlers never wait for Gemini or rebuild. The slowest Route Handler is `/api/uploads`, bounded by upload bandwidth.
+- **No Next.js-side worker / queue.** The Python service is the worker. Concurrency is bounded by the container's thread/process pool, tuned in Compose.
+- **Single source of truth for status.** Postgres. The Python service pushes transitions via webhook; Next.js clients never read Python directly.
+
+### 7.2 Upload ceiling
+
+Hard limit: **50 MB** per `.pptx` in v1 (matches existing Streamlit behavior). Enforced at two layers:
+- Next.js Route Handler rejects `Content-Length > 50 MB` before streaming.
+- Supabase Storage bucket policy sets the same limit.
+
+Above-50MB support is explicitly out of scope for v1; resumable/tus-style uploads are a post-v1 upgrade.
+
+### 7.3 Cancellation
+
+`POST /api/jobs/[id]/cancel` sets `status='cancelled'` in Postgres and POSTs the Python sidecar. The Python task checks `status` at each phase boundary and exits cleanly. Mid-Gemini-call cancellation is best-effort (we don't kill requests in-flight; we drop the result).
+
+---
+
+## 8. Invariant Translation Matrix (resolves preflight §8)
+
+| # | Invariant | Owner in new design | Enforcement |
+|---|---|---|---|
+| 1 | `order_number` is the join key | Python `parse_powerpoint` sets it. Postgres `SlideDescription.orderNumber` mirrors it. Unique constraint `(jobId, slideNumber, orderNumber)`. | Python-side unchanged (`scripts/check_invariants.py --only order_number`). TS side: Prisma schema guarantees it (DB constraint). |
+| 2 | Alt text writes `cNvPr/@descr` | Python rebuild only. TypeScript never writes OOXML. | Unchanged Python invariant check. |
+| 3 | Gemini 60 s backoff | Python `rag_core.py`. | Unchanged Python invariant check. |
+| 4 | Chroma via FastAPI wrapper | Strengthened: **no** Chroma client of any language outside the FastAPI container. | Invariant check extended (§16.4) to scan Next.js TS for `chromadb` or a JS vector-DB client and fail. |
+| 5 | Image normalization | Python `ImageProcessor`. Unchanged. | Unchanged Python invariant check. |
+| 6 | `chroma/` data is not to be cleaned | Now a **named Docker volume** (`chroma_data`), mounted at `/chroma/chroma` inside the Chroma container. Lives outside the repo tree. Closes the `git clean` footgun. | `.gitignore` scan unchanged; new compose-level invariant added to `INVARIANTS.md` (§16.1). |
+| 7 | Group-shape recursion | Python. Unchanged. | Unchanged Python invariant check. |
+| 8 | Consent gate (IRB) | Moved from Streamlit first-page + CSV to `Profile.consentAcceptedAt` + `ConsentEvent` + Next.js middleware (§9). Stronger than before: cannot bypass by direct URL. | New middleware-level assertion; new test in §15.3. |
+| 9 | Branches are a pipeline | `refactor/nextjs-migration` → PR → merge into `Aggrement`'s successor (`main` after cutover). No lateral merges with `Prod-v1`. Docker Compose assets cherry-picked, not merged. | Branching doc updated (§16.3). |
+| 10 | Tech-debt gaps (§10.x) | Closed by construction: 10.1 (plaintext secrets → Vercel env + Compose env from a secured `.env`; further upgrade to Secret Manager is noted in §11.6), 10.4 (public ports closed; Caddy fronts only the FastAPI), 10.6 (Vercel deploys + GitHub Actions = implicit CI), 10.7 (Vercel scales the UI; backend SPOF remains — noted), 10.8 (compose + Caddyfile + Dockerfiles all in repo). | Update to `INVARIANTS.md §10` at cutover. |
+| 11 | Configuration of record | **Satisfied on day 1.** Docker Compose, Dockerfile.api, Caddyfile, Prisma schema, middleware, and every env var template (`.env.example`) are committed on this branch. Changes on the VM must land here first. | New invariant-level test: `docker compose config` must parse, `Caddyfile fmt` clean. |
+
+---
+
+## 9. Consent Gate (resolves preflight §9)
+
+### 9.1 Flow
+
+1. A user signs in via Supabase Auth.
+2. `middleware.ts` inspects every non-auth, non-asset request. If `profile.consentAcceptedAt IS NULL`, it rewrites to `/consent`.
+3. `/consent` is an RSC that fetches the current consent text from the repo (`docs/irb/consent-v1.md`, authoritative, version-pinned in code), plus the user's `consentVersion` if present.
+4. On submit, a Server Action:
+   a. inserts a `ConsentEvent` row with IP hash + UA + version,
+   b. updates `Profile.consentAcceptedAt` and `consentVersion`,
+   c. redirects to `/upload`.
+5. The consent gate **cannot** be bypassed by deep-linking to `/upload`, `/process/*`, `/review/*`, `/download/*`, `/api/uploads`, or `/api/jobs/*` — middleware runs first.
+
+### 9.2 IRB specifics — **[PENDING MANUAL CONFIRMATION]**
+
+- Exact wording of `docs/irb/consent-v1.md`.
+- Exact list of fields to store on `ConsentEvent` (IP policy, UA, pseudonym, research cohort).
+- Retention horizon.
+- Whether consent-version bumps require re-consent (default: yes).
+- Whether minors-data policy applies.
+
+The technical substrate (Profile flag + append-only event log + middleware) is frozen regardless of the above.
+
+### 9.3 Data migration
+
+The legacy `consent_responses.csv` on the prod VM is imported as historical `ConsentEvent` rows, or archived off-VM if IRB prefers a clean break. **[PENDING]** — the choice is a policy call, not an architectural one.
+
+---
+
+## 10. Auth & Identity (resolves preflight §10)
+
+- **Provider:** Supabase Auth.
+- **v1 sign-in:** email + magic link.
+- **v1.1+ sign-in:** SUNY SSO via Supabase's external OIDC provider. Target post-cutover.
+- **Session:** Supabase cookie session consumed server-side by `@supabase/ssr`. No JWT in localStorage.
+- **Server access:** Route Handlers and Server Actions get the user via `supabaseServerClient(cookies())`. Unauthed → 401.
+- **Middleware:** enforces auth + consent on all non-auth routes.
+- **Service-role key:** stored as `SUPABASE_SERVICE_ROLE_KEY` in Vercel env only. Never in a client bundle. Used only from Route Handlers that need to bypass RLS (admin/debug endpoints) — none in v1.
+
+Public-internet exposure of Gemini-bearing endpoints (§10.4 of INVARIANTS) is now closed by construction: `/api/jobs/*` requires a session; `/jobs/*` on the Python side requires the shared secret; the raw Chroma port 8000 is **not** published outside the Docker network (§11.3).
+
+---
+
+## 11. Production Deployment (resolves preflight §11)
+
+### 11.1 Split hosting
+
+| Tier | Host | Runtime | Code location |
+|---|---|---|---|
+| Next.js UI | **Vercel** | Node 22 (Vercel's current default) | `nextjs/` in this repo (see §13.1). |
+| Python FastAPI + Chroma | **GCP VM** (`instance-20250905-023343-pub`), Docker Compose | Python 3.11-slim + Chroma image | `docker-compose.yml`, `Dockerfile.api`, `Caddyfile` — cherry-picked from `Prod-v1`. |
+
+### 11.2 Compose stack (post-strip)
+
+The `Prod-v1` compose file has **four** services: `chroma`, `chroma-api`, `web` (Streamlit), `caddy`. We keep three and drop `web`:
+
+```
+services:
+  chroma:
+    # unchanged from Prod-v1: ghcr.io/chroma-core/chroma:latest
+    # volume mount changes from ./chroma-db (bind) to a named volume `chroma_data`
+    # closes invariant #6's git-clean footgun.
+  chroma-api:
+    # build: Dockerfile.api, unchanged
+    # ENV adds: PROCESSOR_SHARED_SECRET, WEBHOOK_URL (=Vercel app URL)
+  caddy:
+    # Caddyfile reverse_proxy changes from web:8501 to chroma-api:8001
+    # new host: api.brockportsigai.org (or a subdomain TBD). Public port 443 only.
+```
+
+**Deleted:** the `web` service, both `ports: "8501:8501"` and `ports: "8000:8000"` mappings to the public side (8000 stays container-internal; 8001 is reached only through Caddy/443).
+
+### 11.3 Network posture
+
+- Public ingress on the VM: TCP/443 only (Caddy). TCP/80 redirects to 443.
+- GCP firewall rules `allow-8501` and `allow-8001` are **deleted** at cutover (invariant §10.4 closes).
+- Streamlit systemd units (`streamlit-app`, `chroma-api`, `chroma-db`) are **stopped and disabled** at cutover. Rollback re-enables them if needed (§14.4).
+- `chroma` service is reachable only inside the `sap_net` Docker network.
+
+### 11.4 Secrets
+
+| Secret | Lives in | Injected via |
+|---|---|---|
+| `DATABASE_URL`, `DIRECT_URL` | Vercel env | Vercel dashboard (encrypted) |
+| `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Vercel env (public-safe) | Vercel dashboard |
+| `SUPABASE_SERVICE_ROLE_KEY` | Vercel env (server-only) | Vercel dashboard |
+| `PROCESSOR_SHARED_SECRET` | Vercel env AND VM `.env` | both sides check a shared HMAC header |
+| `PROCESSOR_BASE_URL` (e.g. `https://api.brockportsigai.org`) | Vercel env | Vercel dashboard |
+| `GOOGLE_API_KEY` | VM `.env` only | Docker Compose `env_file` |
+| `WEBHOOK_URL` (Vercel app URL), `WEBHOOK_SIGNING_SECRET` | VM `.env` only | Docker Compose `env_file` |
+| `SUPABASE_STORAGE_DOWNLOAD_URL`s | generated per request | Next.js route handlers |
+
+The VM `.env` file is `chmod 600` and owned by a dedicated user. This closes the plaintext-`.env`-in-repo-root risk without adding Secret Manager. Upgrade path to GCP Secret Manager is documented as post-v1 and does not block cutover.
+
+### 11.5 TLS
+
+- `api.brockportsigai.org` (VM) — Caddy + Let's Encrypt ACME (from the existing Caddyfile).
+- `access.brockportsigai.org` (Vercel) — Vercel-managed cert.
+- DNS: `access` points at Vercel's edge; `api` points at the VM's external IP. **[PENDING]** DNS flip date.
+
+### 11.6 Observability
+
+- Next.js: Vercel Logs + `@vercel/otel` → (target) Google Cloud Logging. Pino for structured logs. Sentry for errors (post-v1 if needed).
+- Python: `docker logs` + Google Cloud Ops Agent already installed on the VM.
+- Both sides emit a `jobId` in every log line for correlation. Required by SOP.
+
+### 11.7 Start / stop scripts retired
+
+The existing `start_scripts/` directory on the VM (Streamlit + systemd) is archived into `backups/python-legacy/start_scripts/` on this branch and deleted from the VM post-cutover. Replacement is `docker compose up -d` + a one-line `systemd` unit that runs that command at boot (`docker-compose@sap.service`) — committed to `deploy/systemd/` on this branch.
+
+---
+
+## 12. Chroma Coexistence (resolves preflight §12)
+
+- **Keep** the FastAPI wrapper exactly as-is. Invariant #4 holds.
+- **Keep** the `chromadb` Python client as the only client of Chroma in the system.
+- **Do not** introduce a JS Chroma client.
+- **Do not** replace Chroma with pgvector / Pinecone / Supabase Vector in v1. Noted as a plausible post-v1 consolidation (the Supabase-already-there lever) but deliberately not in scope.
+- **Embedding-function parity is a non-issue** because Chroma continues to use its built-in default embedder inside the same container.
+- **Data migration:** existing collections on the prod VM are **discarded** at cutover. New uploads re-index from zero. Accepted cost because:
+  - Collections are cheap to rebuild on upload.
+  - Prod's in-repo `chroma/` directory is messy (invariant #10.5 debt) and migrating it while also moving to a named volume doubles risk.
+  - The system has never relied on long-lived collections across decks.
+
+---
+
+## 13. Repository Layout & `nextjs-impl` Audit (resolves preflight §13)
+
+### 13.1 Proposed repo layout on this branch
+
+```
+/
+├── app/                       # Python — unchanged (source of invariants #1–#7)
+│   ├── chroma-api/
+│   ├── models/
+│   ├── pptx_rag_quizzer/
+│   ├── ppt_notes.py
+│   └── processing_service/    # NEW — /jobs/* endpoints (same FastAPI app)
+├── deploy/                    # NEW — configuration of record (invariant #11)
+│   ├── docker-compose.yml     # cherry-picked + stripped from Prod-v1
+│   ├── Dockerfile.api
+│   ├── Caddyfile
+│   ├── env/
+│   │   └── .env.example
+│   └── systemd/
+│       └── docker-compose@sap.service
+├── docs/                      # existing framework
+├── nextjs/                    # NEW — the Vercel app
+│   ├── package.json
+│   ├── next.config.ts
+│   ├── tsconfig.json
+│   ├── prisma/
+│   │   └── schema.prisma
+│   ├── src/
+│   │   ├── app/               # App Router routes per §2.1
+│   │   ├── lib/
+│   │   │   ├── db.ts          # Prisma singleton
+│   │   │   ├── supabase.ts    # server + client helpers
+│   │   │   ├── processor.ts   # HTTP client for the Python sidecar
+│   │   │   └── storage.ts     # Supabase Storage helpers
+│   │   ├── middleware.ts      # auth + consent gate (invariant #8)
+│   │   └── components/        # UI primitives
+│   └── .env.example
+├── scripts/                   # Python — extended (§16.4)
+├── tests/                     # Python — extended with contract tests
+└── backups/
+    └── python-legacy/         # Streamlit + start_scripts at cutover
+```
+
+The existing Python modules are **not moved, renamed, or rewritten** by this design. The only Python change on this branch is the new `app/processing_service/` module.
+
+### 13.2 Disposition of `nextjs-impl` branch files
+
+| File on `nextjs-impl` | Disposition on `refactor/nextjs-migration` |
+|---|---|
+| `package.json` | Carry forward; re-pin only if security advisories force it. |
+| `next.config.ts`, `tsconfig.json`, `eslint.config.mjs`, `postcss.config.mjs` | Carry forward. |
+| `src/app/layout.tsx`, `globals.css` | Carry forward; re-theme when final palette clears WCAG AA (§15.5). |
+| `src/app/page.tsx` | **Delete.** Replace with RSC-first landing per §2.1. |
+| `src/app/api/process/route.ts` | **Delete.** Replaced by `/api/uploads` + `/api/jobs/*` + `/api/webhooks/processor`. |
+| `src/lib/pptx-utils.ts` | **Delete.** Python owns PPTX. |
+| `src/lib/gemini.ts` | **Delete.** Python owns Gemini. |
+| `src/lib/chroma.ts` | **Delete.** Python owns Chroma. |
+| `AGENTS.md` ("this is NOT the Next.js you know") | Carry forward as `nextjs/AGENTS.md`. Augment with RSC/Client + Edge-forbidden rules. |
+| `CLAUDE.md` | Delete — superseded by repo-root `AGENTS.md`. |
+| `public/*` | Carry forward; swap marketing assets later. |
+| `backups/python-legacy/` | Carry forward pattern; at cutover, Streamlit goes here. |
+
+---
+
+## 14. Cutover, Rollback, Data Migration (resolves preflight §14)
+
+### 14.1 Phases
+
+- **Phase 0 — parity staging.** Vercel `preview` deployments + a staging VM (or staging Compose project on the same VM, distinct ports). Runs through a fixed deck-fixture corpus (§15.2).
+- **Phase 1 — private beta.** `access.brockportsigai.org/v2` routed to Vercel via a nginx split on the VM (or a Vercel rewrite on a non-production subdomain). Invited accessibility coordinators only.
+- **Phase 2 — dual run.** `access.brockportsigai.org` swings to Vercel. Streamlit remains reachable on a private port (`8501` bound to `127.0.0.1`, SSH-tunnel only) for 30 days.
+- **Phase 3 — sunset.** Streamlit systemd units uninstalled. `backups/python-legacy/` retains the code.
+
+### 14.2 Cutover steps (sequence)
+
+1. Freeze `Aggrement` (**[PENDING]** date).
+2. Merge `refactor/nextjs-migration` → `Aggrement`-successor branch (new `main`).
+3. Deploy Compose stack to VM: `docker compose -f deploy/docker-compose.yml up -d --build`.
+4. Delete GCP firewall rules `allow-8501`, `allow-8001`.
+5. Bind Streamlit systemd units to `127.0.0.1` (not disabled yet).
+6. Flip DNS: `access.brockportsigai.org` A-record → Vercel.
+7. Smoke test: `scripts/smoke_test.py --url https://access.brockportsigai.org --strict` (existing script).
+8. Announce cutover.
+
+### 14.3 Rollback (T < 24 h)
+
+- **Full rollback:** revert DNS, re-add firewall rules, re-enable Streamlit systemd units. Max 10 minutes.
+- **Partial rollback:** keep Vercel up, disable `/api/uploads` with a feature flag (`NEXT_PUBLIC_READ_ONLY=true`), route users to the private Streamlit via a secondary domain. Preserves in-flight review work in Postgres.
+
+`docs/ops/SOP_ROLLBACK.md` gets a new section for these two paths — **[PENDING]** authoring (tracked as a post-design PR).
+
+### 14.4 Data migration
+
+| Data | Action |
+|---|---|
+| Existing Chroma collections on the VM | Discard. Re-index from new uploads. |
+| Streamlit-era uploaded decks on the VM's `/tmp` | Discard. |
+| `consent_responses.csv` | Import into `ConsentEvent` OR archive per IRB — **[PENDING]**. |
+| Any in-flight Streamlit sessions at cutover | Discarded. Announced in the cutover notice. |
+
+---
+
+## 15. Testing, A11y QA, Observability (resolves preflight §15)
+
+### 15.1 Test layers
+
+| Layer | Tool | Scope |
+|---|---|---|
+| Python unit | `pytest` | Existing + new `processing_service/` orchestration tests. |
+| Python contract | `pytest` + `fastapi.testclient` | `/jobs/*` request/response schemas. |
+| TS unit | `vitest` | Prisma model invariants, middleware, Route Handler logic (mocking Python and Supabase). |
+| TS integration | `playwright` | End-to-end `/upload → /review → /download` against a staging stack. |
+| PPTX round-trip | `pytest` on Python side | One fixture per invariant: group shapes, WMF image, RGBA image, large deck, empty notes. |
+| Accessibility (deck output) | Manual via PowerPoint Accessibility Checker on every fixture deck — rotating owner **[PENDING]**. |
+| Accessibility (UI) | `axe-core` via Playwright on every page. CI fails on a11y violations above a baseline. |
+
+### 15.2 Deck fixture corpus
+
+Committed under `tests/fixtures/pptx/`. Each fixture targets one invariant:
+
+- `groups.pptx` — nested group shapes (invariant #7).
+- `wmf.pptx` — WMF/EMF image (invariant #5).
+- `palette.pptx` — paletted PNG (invariant #5).
+- `large.pptx` — 50 slides × 5 images (performance ceiling §7.2).
+- `order.pptx` — intentionally shuffled shapes to catch `order_number` drift (invariant #1).
+
+### 15.3 CI (GitHub Actions)
+
+Extend `.github/workflows/preflight.yml` already shipped on `feature/agent-ops-framework`:
+
+- **Python job** (existing): `doctor`, `check_invariants`, `preflight`, pytest.
+- **TypeScript job** (new): `pnpm -C nextjs lint`, `pnpm -C nextjs build`, `tsc -p nextjs --noEmit`, `pnpm -C nextjs test`, Prisma schema validation.
+- **Compose job** (new): `docker compose -f deploy/docker-compose.yml config` (lint only), Caddyfile format check.
+- **Invariant expansion job** (new): extended `check_invariants.py` (§16.4).
+
+### 15.4 Observability
+
+- Every request logs `jobId`, `userId`, `route`, `duration_ms`, `status`.
+- Python side logs `gemini_retry_count`, `gemini_total_delay_ms` per job.
+- Postgres view `v_job_summary` aggregates per-day counts of each terminal state.
+
+### 15.5 UI a11y baseline
+
+- All text on the UI ≥ WCAG AA contrast (the current `nextjs-impl` dark purple gradient is retained **only if** it clears; otherwise re-theme is a blocker before v1).
+- Keyboard-navigable upload, review, and download flows.
+- Every image in the review grid has an `aria-label` sourced from the current description.
+- Form controls have associated `<label>`s.
+- The review editor is a plain `<textarea>`, not a contenteditable.
+- Screen-reader test on at least one of NVDA / VoiceOver per release.
+
+---
+
+## 16. Framework Integration (resolves preflight §16)
+
+### 16.1 Documents that must be updated after this design lands (same branch)
+
+- `docs/PROJECT_OVERVIEW.md` — add v2 architecture section.
+- `docs/AGENT_CONTEXT.md` — add Next.js + Supabase entries; mark Streamlit as legacy.
+- `docs/PRODUCTION_ENVIRONMENT.md` — rewrite for split hosting + Compose stack.
+- `docs/guardrails/INVARIANTS.md` — update §2, §4, §6, §8, §10, §11 per §8 above. Add invariant #12 (see §16.3).
+- `docs/guardrails/BRANCHING.md` — retire `nextjs-impl`; formalize `refactor/nextjs-migration` → `main` flow; forbid lateral merges with `Prod-v1` beyond the compose cherry-pick.
+- `docs/ops/SOP_DEPLOY.md` — split into SOP_DEPLOY_VERCEL and SOP_DEPLOY_BACKEND.
+- `docs/ops/SOP_ROLLBACK.md` — §14.3 above.
+- `docs/ops/SOP_SECRETS.md` — Vercel + VM `.env` flows.
+- `scripts/` and `.github/workflows/preflight.yml` — §15.3.
+
+### 16.2 New framework documents
+
+- `docs/guardrails/NEXTJS_RULES.md` — RSC vs Client, Server Action vs Route Handler, Edge forbidden, secret-scope rules.
+- `docs/guardrails/PYTHON_SERVICE_BOUNDARY.md` — explicit list of what the Python sidecar owns and what Next.js must never duplicate.
+- `docs/ops/SOP_DEPLOY_VERCEL.md`, `docs/ops/SOP_DEPLOY_BACKEND.md` — replace the single SOP_DEPLOY with two.
+- `docs/refactor/NEXTJS_MIGRATION_DESIGN.md` — this file.
+
+### 16.3 New / modified invariants
+
+- **Invariant #12 (new) — Service boundary.** TypeScript in this repo must not open a `.pptx`, must not call Gemini, must not talk to Chroma, and must not bypass the Python sidecar for any job-processing action. Enforced by a new `check_invariants.py` check (§16.4).
+- **Invariant #2 (updated) — Python-only.** The cNvPr/@descr write is allowed only in Python files. Any TypeScript that references `cNvPr` or `descr=` triggers a hard fail.
+- **Invariant #4 (strengthened).** Extends the existing "Chroma via FastAPI wrapper" rule to explicitly forbid any JavaScript Chroma client.
+- **Invariant #6 (closed).** Data lives in Docker volume `chroma_data`. `./chroma/` under the repo is deleted post-cutover. Invariant text updated accordingly.
+- **Invariant #8 (evolved).** Consent gate is now Profile flag + middleware + event log, not a Streamlit page + CSV.
+- **Invariant #11 (satisfied).** Deploy configuration lives in `deploy/`.
+
+### 16.4 `check_invariants.py` extensions
+
+Additions to the existing checks (no change to passing checks on `feature/agent-ops-framework`):
+
+| Key | What it checks |
+|---|---|
+| `ts_no_pptx` | No `.ts`/`.tsx` under `nextjs/` opens a .pptx (no `adm-zip`, no `jszip`, no `xml2js`, no `officegen`, no `pptxgenjs`). |
+| `ts_no_gemini` | No `.ts`/`.tsx` imports `@google/generative-ai` or posts to `generativelanguage.googleapis.com`. |
+| `ts_no_chroma` | No `.ts`/`.tsx` imports `chromadb` or matches a JS vector-DB client allowlist. |
+| `ts_no_ooxml_strings` | No `.ts`/`.tsx` contains `cNvPr` or `a:blip`. |
+| `compose_strips_streamlit` | `deploy/docker-compose.yml` has no service named `web` after cutover PR lands. |
+| `no_public_internal_ports` | `deploy/docker-compose.yml` publishes only `80`/`443` on host. |
+| `middleware_guards_consent` | `nextjs/src/middleware.ts` contains the consent check (regex probe). |
+
+Each check added in this section is documented in `INVARIANTS.md` with rationale + check command.
+
+### 16.5 Ownership & archival
+
+- Refactor reviewer: **[PENDING MANUAL CONFIRMATION]** — single CODEOWNER for `nextjs/`, `deploy/`, `prisma/`.
+- This document becomes historical and is moved to `docs/refactor/history/NEXTJS_MIGRATION_DESIGN.md` at cutover. Post-cutover changes do not edit this file; they land via regular `REFACTOR.md` PRs.
+
+---
+
+## 17. Resolved Strategic Bets (resolves preflight §17)
+
+| Bet | Resolution | Consequence |
+|---|---|---|
+| Language monoculture vs polyglot | **Polyglot.** TypeScript UI + Python backend. | Long-term ops cost accepted; python-pptx fidelity preserved. |
+| Runtime monoculture vs platform | **Split.** Vercel + self-hosted Docker. | Two deploy pipelines; trade-offs acknowledged in §11, §14. |
+| State: cookies vs database | **Database (Supabase Postgres + Prisma).** | New infra accepted; enables resumable jobs, auth-gated downloads, IRB-grade consent tracking. |
+| RSC-first vs Client-first | **RSC-first.** Client only for interactivity pockets. | Existing `nextjs-impl` page.tsx discarded. |
+| Auth now vs never | **Now (Supabase Auth).** | Invariant #10.4 closes; per-user cost caps become enforceable. |
+| Re-index vs migrate vectors | **Re-index.** | Zero-migration path; invariant #6's data-dir debt is paid off at the same time. |
+
+---
+
+## 18. Open items (**[PENDING MANUAL CONFIRMATION]**) — summary
+
+These do not block any code work inside `nextjs/` or `deploy/`. They block cutover or IRB sign-off.
+
+1. Hard feature-freeze date on `Aggrement`.
+2. DNS cutover date for `access.brockportsigai.org`.
+3. IRB retention policy and exact `ConsentEvent` field list.
+4. Whether `consent_responses.csv` is imported or archived.
+5. Subdomain for the Python API (`api.brockportsigai.org` assumed).
+6. Per-user Gemini cost cap numbers (requests/day, bytes/day).
+7. Owner of prompt changes going forward (prompt freeze anchor).
+8. UI palette a11y sign-off (keep `nextjs-impl` theme vs. re-theme).
+9. Baseline KPI measurements from live Streamlit (upload→download wall time, Gemini cost/deck, p95 TTI).
+10. CODEOWNER for `nextjs/`, `deploy/`, `prisma/`.
+11. Whether SUNY SSO replaces magic-link in v1.1 or later.
+12. Whether Streamlit stays reachable on `127.0.0.1:8501` for 30 days post-cutover or is uninstalled immediately.
+
+---
+
+## 19. Halt
+
+This document is the design. No `.tsx` or `.py` files were modified producing it. The next step is:
+
+1. Human review of this file.
+2. Per-decision confirmation of the **[PENDING]** items.
+3. Then, and only then, scaffold `nextjs/`, `deploy/`, and the new `app/processing_service/` module in follow-up PRs, each using `docs/templates/REFACTOR.md` and referencing this document by section.

--- a/docs/refactor/NEXTJS_MIGRATION_PREFLIGHT.md
+++ b/docs/refactor/NEXTJS_MIGRATION_PREFLIGHT.md
@@ -1,0 +1,495 @@
+# Next.js Migration — Preflight Discovery
+
+> **Status:** Draft. Questions only, no answers yet. Awaiting human review before any code moves.
+> **Branch:** `refactor/nextjs-migration`
+> **Scope:** Port the Streamlit + FastAPI + ChromaDB stack described in `docs/PROJECT_OVERVIEW.md`, `docs/AGENT_CONTEXT.md`, and `docs/PRODUCTION_ENVIRONMENT.md` onto the Next.js 16 App Router scaffold that already exists on the `nextjs-impl` branch.
+> **Hard constraints carried over:** every invariant in `docs/guardrails/INVARIANTS.md`. Nothing below may be answered in a way that violates them without an explicit exception in that file.
+
+This is a **discovery document**, not a design. Every section below is a question or a set of questions that need to be answered before any .tsx or .py file on this branch is touched. Each question is phrased so that the answer forces a concrete architectural decision.
+
+---
+
+## 0. Reading order
+
+Answer the sections in this order. Later sections assume earlier ones are settled.
+
+1. [Scope & End-State](#1-scope--end-state) — what "done" means.
+2. [Stage → Component Mapping](#2-stage--component-mapping) — UI architecture.
+3. [Backend Surface Mapping](#3-backend-surface-mapping) — where Python logic goes.
+4. [PPTX Parsing & Rebuild Strategy](#4-pptx-parsing--rebuild-strategy) — the riskiest port.
+5. [RAG Pipeline Port](#5-rag-pipeline-port) — Gemini + Chroma over the wire.
+6. [State, Session, and Persistence](#6-state-session-and-persistence) — the biggest Streamlit-shaped hole.
+7. [Long-Running Work & File Uploads](#7-long-running-work--file-uploads) — timeout math.
+8. [Invariant Translation Matrix](#8-invariant-translation-matrix) — line-by-line.
+9. [Consent Gate (IRB)](#9-consent-gate-irb) — the non-negotiable.
+10. [Auth & Identity](#10-auth--identity) — new problem Streamlit never solved.
+11. [Production Deployment](#11-production-deployment) — replacing systemd bare-metal.
+12. [Coexistence with the Chroma Service](#12-coexistence-with-the-chroma-service) — keep or replace?
+13. [Existing `nextjs-impl` Scaffold Audit](#13-existing-nextjs-impl-scaffold-audit) — what to keep, what to burn.
+14. [Cutover, Rollback, Data Migration](#14-cutover-rollback-data-migration) — flip-day plan.
+15. [Testing, Accessibility QA, Observability](#15-testing-accessibility-qa-observability) — how we'll know.
+16. [Framework Integration](#16-framework-integration) — fitting this into the ops framework we just built.
+
+---
+
+## 1. Scope & End-State
+
+The answers here become the non-negotiable assumptions for every later section.
+
+1.1. Is the Next.js app the **replacement** for the Streamlit deployment at `https://access.brockportsigai.org/accessibility`, or does it coexist on a new subpath (e.g. `/v2`) during a parallel-run window? If coexist, for how long and who owns the cutover signal?
+
+1.2. Which branch is the source of behavior truth for v2 parity — `main`, `Aggrement` (currently live, carries the IRB consent gate), or `Prod-v1` (documented Docker stack, not actually running)? If the answer is `Aggrement`, the IRB consent flow (invariant #8) is in scope on day 1.
+
+1.3. What is the **hard feature freeze** for v1 Streamlit during the migration? If Streamlit keeps accepting changes, which changes are in scope to re-port and which are frozen?
+
+1.4. Are we targeting a Node-only runtime, or is there room to keep `app/chroma-api/` (FastAPI) running in place and only port the UI + orchestration? This one question forks the entire plan.
+
+1.5. What are the product-level KPIs the migration must not regress (upload-to-download latency, max deck size, Gemini cost per deck, concurrent users)? Which of these does v1 even measure today?
+
+1.6. What is the planned sunset policy for the Streamlit install on the prod VM — hard stop, or read-only archive?
+
+---
+
+## 2. Stage → Component Mapping
+
+The current UI lives in `app/ppt_notes.py :: main()` and is driven by four values of `st.session_state.processing_stage`: `upload` → `describe_images` → `final_processing` → `download`. Every transition is a server-rendered re-execution of the whole script. Next.js has no equivalent; decisions here determine whether the app is server-first or client-first.
+
+2.1. Which of the four stages should be a **React Server Component** (static shell, no interactivity) vs. a **Client Component** (stateful, event handlers)? Candidate split to confirm or reject:
+
+| Stage | Candidate RSC boundary | Candidate Client boundary |
+|---|---|---|
+| `upload` | Page shell, copy, branding, stepper skeleton | File picker, drag-drop handler, progress UI |
+| `describe_images` | None — fully interactive | Entire batch-review UI (`<textarea>` edits, next/prev buttons, per-image preview) |
+| `final_processing` | Status polling shell | "Generate" button + progress indicator |
+| `download` | Result summary (server-rendered from job record) | "Download" click handler |
+
+2.1.a. Does every stage need to survive a full page refresh (i.e. stage stored server-side, keyed by a URL param or cookie) or is a refresh-wipes-progress UX acceptable for v1?
+
+2.1.b. The current "Quick Generate & Download" button bypasses review entirely. Does that become a separate `/api/quick-process` route or a toggled code path inside `/api/process`?
+
+2.2. Should the stage state live in the **URL** (e.g. `/process/[jobId]/review`), in a **server-side session**, in **React Context** inside one client component, or in a client-state library (`zustand`, Jotai, Redux Toolkit)? Rank the trade-offs with respect to:
+- Back button behavior (Streamlit currently offers a "← Back" button; URL-driven state matches browser history for free).
+- Shareable / resumable job links (supporting accessibility coordinators sharing WIP jobs).
+- Refresh survivability.
+
+2.3. The existing `nextjs-impl/src/app/page.tsx` is a single 300-line client component that uses `useState<Stage>` and a hard-coded review mockup. Is that prototype the **starting point** we iterate, or do we **discard it** and build from the stage map in 2.1? (If we keep it, item 2.1's server-first split is dead.)
+
+2.4. Does the stepper in the current nextjs-impl prototype stay as the v2 IA, or do we move to a **segmented route** (`/upload`, `/review/[jobId]`, `/result/[jobId]`) so each stage gets its own URL? Segmented routes are the App Router idiom; keeping a single `/` page is not.
+
+2.5. Is **Server-Sent Events** or a WebSocket needed for live progress during batched image description (current code does one `st.write(...)` per image), or is polling the job status from a client component acceptable for v1? Streamlit's implicit streaming is the hardest Streamlit-ism to reproduce.
+
+2.6. Should review edits to alt-text be saved via a **Server Action** (`'use server'` function called from the client) or a **Route Handler** POST? We need to pick one pattern per write path for the whole app and write it down; today's prototype uses only route handlers.
+
+2.7. Which shared UI primitives in the Streamlit app have no direct mapping and therefore require a design decision before building: `st.progress`, `st.spinner`, `st.image` (auto-resize), `st.download_button` (blob streaming), `st.error` (toast vs. inline)?
+
+2.8. What is the accessibility baseline for the chrome itself (stepper, buttons, file picker, progress)? We are shipping an accessibility tool; WCAG 2.1 AA on the UI is table stakes — who signs off, and against what checklist?
+
+---
+
+## 3. Backend Surface Mapping
+
+Today there are two Python entry points the UI talks to:
+
+- `RAGCore` (in-process) — parse, Gemini calls, collection build, context retrieval.
+- `chroma-api` (FastAPI on `:8001`) — REST wrapper around ChromaDB.
+
+Each Python function needs a Next.js home. The matrix below is what needs to be filled in by the answer to this section:
+
+| Current Python entry | Callers | Proposed Next.js home | Runtime |
+|---|---|---|---|
+| `parse_powerpoint(file_object, file_name)` in `app/pptx_rag_quizzer/utils.py` | upload stage | Route Handler `POST /api/process` or Server Action | **node** (not edge) |
+| `RAGCore.create_collection(Presentation)` | upload stage | ? | ? |
+| `ImageProcessor.describe_image(bytes, ext, slide_num, collection_id)` | describe_images stage | ? | ? |
+| `RAGCore.remove_collection(id)` + re-create | final_processing | ? | ? |
+| `process_powerpoint_with_rag_enhanced(...)` | final_processing | ? | ? |
+| `ExtractText_LLM(image_base64, ...)` in `app/ppt_notes.py` | image description path | merges with `ImageProcessor`? | ? |
+| `generate_enhanced_notes_with_context(...)` | final_processing | ? | ? |
+
+3.1. Each row above: **Route Handler, Server Action, or background worker**? Server Actions are ergonomic but have a ~1 MB payload cap and a 30–60 s Vercel/Node-timeout window that WILL be exceeded on a 50-slide deck with image OCR + Gemini describe + Chroma rebuild.
+
+3.2. Every row that calls Gemini or Chroma must run on the **Node runtime** (not Edge) because:
+- `google-generativeai`'s equivalent JS SDK (`@google/generative-ai`) needs Node APIs.
+- `adm-zip` in the existing scaffold is Node-only.
+- `axios` + HTTP to the Chroma wrapper is fine either way, but see 12.x on whether that wrapper survives.
+
+Confirm that no part of this app is a candidate for the Edge runtime. If any part is, identify it now.
+
+3.3. Do we keep the multi-module layout (`lib/pptx-utils`, `lib/gemini`, `lib/chroma`) the existing scaffold started, or do we introduce a domain layer (`lib/domain/presentation.ts`, `lib/domain/alt-text.ts`) that mirrors `app/models/models.py`? The Pydantic invariant (`order_number`, `SlideItem` hierarchy) has to be honored by whatever TS types we pick — see section 4.4.
+
+3.4. Is there a "BFF" boundary we want to enforce — e.g. all Gemini and Chroma keys stay strictly inside route handlers / server actions and are never shipped to the client? Today Streamlit effectively enforces this by running on the server; in Next.js this has to be a written rule.
+
+3.5. What is the error contract between handlers and the UI? The current code leaks Python exceptions into `st.error(...)`; we need a typed error shape (`{ code, message, retryable, jobId? }`) and a question about whether to adopt `neverthrow`, `zod`-validated responses, or plain typed unions.
+
+3.6. Do we want **streaming responses** (React Server Components with `Suspense` + `loading.tsx` boundaries) for the review stage, where image descriptions trickle in as Gemini finishes each one? This is the most natural Next.js rewrite of the batched `st.write(...)` loop but requires commitment to the App Router streaming model.
+
+---
+
+## 4. PPTX Parsing & Rebuild Strategy
+
+This is the riskiest port. `python-pptx` has no faithful Node equivalent, and the current scaffold's `lib/pptx-utils.ts` reimplements *some* of it via `adm-zip` + `xml2js` — well enough to read text and image relationships, but **not** well enough to write back `cNvPr/@descr`, handle group shapes, or manage speaker notes at XML fidelity (line 146 of that file is literally a `console.log` placeholder for alt-text writeback).
+
+4.1. Do we **keep** a Python process for parsing + rebuild (e.g. a FastAPI service co-located with the Next.js app or the existing chroma-api), or **fully port** to TypeScript?
+
+4.1.a. If port: which library? The candidates are:
+- `officegen` — write-only, does not read existing decks.
+- `pptxgenjs` — write-only, generative, not round-trip.
+- `adm-zip` + `xml2js` + hand-rolled XML (current scaffold). Requires us to own the rebuild code path including group-shape recursion (invariant #7) and `cNvPr/@descr` write (invariant #2).
+- `docx4js` / `node-pptx` — review state and maintenance risk.
+- Shelling out to LibreOffice headless — ports deck fidelity but explodes the runtime.
+
+4.1.b. If keep Python: do we invoke it via (a) a sidecar FastAPI service the Next.js route handlers call, (b) `child_process.spawn('python', ...)` per request, or (c) a managed worker queue (BullMQ + a Python consumer)?
+
+4.2. Who owns **re-implementing invariant #1** (`order_number` as the universal join key)? In Python this is set in `parse_powerpoint` by incrementing `order_number` in the shape loop. The scaffold's `PptxProcessor` currently uses `id: 'text-${slideNumber}-full'` / `id: 'img-${slideNumber}-${relId}'` with no `order_number` field. This will silently misalign alt text during rebuild. What type contract replaces `app/models/models.py :: SlideItem.order_number` in TypeScript, and where is it enforced (zod schema? branded type?)?
+
+4.3. Who owns **re-implementing invariant #2** (`cNvPr/@descr` write)? What's the plan for:
+- Locating `<p:nvPicPr><p:cNvPr/>` under each picture in `slideN.xml`.
+- Setting or replacing the `descr=` attribute.
+- Preserving the rest of the XML (namespaces, xml:space, comments).
+- Also setting python-pptx's fallback `alternative_text` equivalent (the `a:blip` / descrElement pair — or just `cNvPr/@descr` in the TS port).
+- Writing the .pptx back as a valid OOXML zip (central directory, compression, content types).
+
+4.4. TypeScript type fidelity for `Presentation / Slide / SlideItem / Image / Text`: generate from a zod schema? Handwrite? Share via a generated package? Whichever answer, it must include `order_number: number` as a required, non-defaulted field (invariant #1).
+
+4.5. Image normalization (invariant #5) — WMF/EMF → PNG, paletted → RGB. The current scaffold has none of this. What TS equivalent of `Pillow.convert('RGB')` and the WMF branch do we use (sharp + ImageMagick shell? `@resvg/resvg-js`? `imagemagick-native`?) and does it run on the same Node process or a separate service?
+
+4.6. Group-shape recursion (invariant #7) — `xml2js` flattens `<p:grpSp>` differently from python-pptx's shape tree. Define the recursion in TS, including test fixtures covering grouped images and nested groups.
+
+4.7. Chart and table alt-text (currently written as `shape.alternative_text` in Python) — are these in scope for v1 or explicitly deferred?
+
+4.8. What's the max deck size we promise to handle? 50 slides × ~5 images × ~2 MB images = ~500 MB in memory on the server per upload. Does that fit in a single Node process, or do we need to stream / chunk from upload → disk → worker?
+
+---
+
+## 5. RAG Pipeline Port
+
+Today `RAGCore` (in `app/pptx_rag_quizzer/rag_core.py`) orchestrates four things:
+
+- Create a ChromaDB collection, add per-slide combined text.
+- Query the collection by slide number or by query text.
+- Call Gemini (text + image-with-prompt) with a 60 s `ResourceExhausted` backoff.
+- Cache LLM model handle in a module-level global (`_llm_model_cache`).
+
+The `ImageProcessor` wraps a 4-stage pipeline (OCR → enhanced description → lambda-index context → final description) with a 1-hour in-process TTL cache.
+
+5.1. Which Gemini client do we pick? `@google/generative-ai` is the obvious choice, but it has a different streaming API, different error shapes, and does **not** raise the same `Resource has been exhausted` string that invariant #3's check grep'd for. Who writes the TS analog of the 60 s backoff + retry, and where does the check_invariants guard point?
+
+5.2. Where does the Gemini API key live at runtime?
+- `process.env.GOOGLE_API_KEY` in route handlers (server only) — same shape as Streamlit.
+- GCP workload identity / service account — tidier, needs Vercel/Cloud Run integration.
+- Secret Manager — requires infra we don't yet have (see SOP_SECRETS §6).
+
+5.3. Do we preserve the per-request `ImageProcessor.context_cache` (TTL 3600 s) across requests in Next.js? Options:
+- In-memory per-node: cheap, wrong under multi-node deploys.
+- Redis/Upstash: correct, new infra.
+- Drop the cache for v1: accept extra Gemini cost.
+
+5.4. The current `describe_image` runs Stage 1 OCR (currently disabled — `utils.py :: ExtractText_OCR` returns a placeholder). Is OCR in scope for v2 day 1? If yes, native Node (`tesseract.js`) vs. a Python sidecar. If no, document the regression explicitly.
+
+5.5. Lambda Index (`get_context_with_lambda_index` in `ImageProcessor`) — does the logic port straight as a TS function, or is it a candidate to replace with a vector-DB-native re-ranker? List the minimum behavioral invariants before rewriting.
+
+5.6. The `get_random_slide_context`, `get_random_slide_with_image`, `get_context_from_slide_number` reads all return a weird shape where `documents` can be a list of characters and must be `.join()`ed — a bug waiting to bite. Do we preserve the shape for wire compatibility or fix it during the port (and risk contract drift with the Python FastAPI wrapper if both stay alive)?
+
+5.7. Prompt fidelity: the Gemini prompts in `ppt_notes.py :: ExtractText_LLM`, `rag_core.py :: prompt_gemini*`, and `image.py` embed specific phrasing ("under 125 characters for alt text", "Image Information:", etc.). Do we copy them verbatim, version them (`prompts/v1.ts`), or re-write? Accessibility output quality is sensitive to prompt drift; lock the answer before the port.
+
+5.8. Cost accounting: is there a per-user or per-deck cap to enforce in the TS version that Streamlit never had (rate limit, quota, API-key-per-tenant)?
+
+---
+
+## 6. State, Session, and Persistence
+
+Streamlit gives us `st.session_state` for free — a per-user server-side dict keyed by the WebSocket. Next.js gives us nothing equivalent. Every state bullet below needs a concrete home.
+
+| State today in `st.session_state` | What it holds | Proposed Next.js home |
+|---|---|---|
+| `processing_stage` | stage enum | URL segment / query? DB? cookie? |
+| `presentation_model` | full Pydantic `Presentation` incl. `bytes` images | ? |
+| `rag_core` | in-process singleton | not serializable, must be rebuilt per request |
+| `image_processor` | in-process, holds `context_cache` | see 5.3 |
+| `collection_id` | Chroma collection name | DB row or cookie |
+| `current_batch`, `batch_size` | pagination | URL param |
+| `uploaded_file_name`, `file_bytes` | 50+ MB binary | object store (GCS? local disk? tmpfs?) |
+| `output_path` | server filesystem path to accessible.pptx | object store URL |
+
+6.1. Do we introduce a **database** (Postgres? SQLite on the VM? Firestore?) and a `Job` / `Presentation` / `ImageDescription` schema, or do we lean on the existing Chroma collection + an object store and avoid adding a DB? Rank the two paths by net-new-infra count, failure modes, and migration toil.
+
+6.2. Where do **uploaded `.pptx` blobs** live between stages? Options:
+- Node-local `/tmp` keyed by `jobId` — breaks under multi-node, survives single-VM.
+- GCS bucket — requires bucket + credentials.
+- Base64-in-DB — bad, but noting it because it's what Streamlit's `st.session_state.file_bytes` basically does.
+
+6.3. Where does the **rebuilt accessible deck** live for download? Same options as 6.2, but adds the question: does the download URL expire, require auth, or include a CSRF token? Streamlit's `st.download_button` bypasses all of this by serving bytes directly; we have to replace that pattern.
+
+6.4. Do we version the job schema from day 1 (`jobs.schema_version`) so we can evolve it without breaking in-flight jobs during future deploys?
+
+6.5. Does the UI support **resuming an in-progress job** from a new browser or tab? If yes, auth is required (section 10). If no, the job ID can be unguessable-random and URL-shared.
+
+6.6. What's the retention policy for jobs (minutes? days?) and by extension for uploaded decks and Chroma collections? This matters for both Gemini cost and IRB data handling on the Aggrement branch (see §9).
+
+---
+
+## 7. Long-Running Work & File Uploads
+
+Streamlit's `st.spinner(...)` happily blocks for minutes. Next.js Route Handlers (Node runtime, Vercel) cap at 60 s default (configurable to ~5 min on Vercel Pro, effectively unbounded on self-hosted). Answer these before picking a hosting target.
+
+7.1. What is the worst-case end-to-end time for a full run on a 50-slide deck with 30 images, given current Gemini latency + 60 s backoff + Chroma add + rebuild? Measure on the live Streamlit and put a number here.
+
+7.2. Given that number, do we:
+- Run synchronously in a Route Handler and raise the Node timeout (self-host only, fragile).
+- Split into **async job** — Route Handler accepts upload, enqueues, returns `jobId`; a worker processes; client polls `/api/jobs/[id]`. New infra: queue.
+- Use **Server Actions + streaming** (`useFormState`/`useOptimistic`) with progressive RSC rendering.
+
+7.3. If async: which queue? Options:
+- BullMQ + Redis (adds Redis).
+- Postgres-backed queue (adds Postgres; might already be on from 6.1).
+- Google Cloud Tasks / Pub/Sub (adds GCP infra).
+- Inline `setImmediate` + in-memory map (dev-only, do not ship).
+
+7.4. File upload ceiling: Next.js `formData.get('file')` loads the whole file into memory. For 50 MB decks this is fine, for 500 MB it is not. Do we switch to chunked / resumable upload (tus, UploadThing, GCS signed URLs) up-front, or gate deck size at 50 MB and defer?
+
+7.5. How do we surface progress? Option matrix:
+- Polling `/api/jobs/[id]` every 2 s — simplest, works everywhere.
+- Server-Sent Events stream — better UX, slightly more infra.
+- Websocket — overkill for one direction.
+- React Server Components streaming with `Suspense` — ergonomic but ties us to RSC, may not fit a queued worker model.
+
+7.6. Cancel / abort semantics — Streamlit has none; what do we promise?
+
+---
+
+## 8. Invariant Translation Matrix
+
+Each row in `docs/guardrails/INVARIANTS.md` is a constraint the Next.js port must honor. Answer one question per row.
+
+| # | Invariant | Next.js-era question |
+|---|---|---|
+| 1 | `order_number` is the join key | Which TS type owns it? Where is it asserted (zod? branded type)? How does `scripts/check_invariants.py --only order_number` become a TS lint / test? |
+| 2 | Alt text writes to `cNvPr/@descr` | Does our OOXML writer do this faithfully? What automated test proves it on every PR (see 15.x)? Is the existing `check_alt_text_xml` regex check still valid, or do we rewrite it to scan `src/lib/pptx/**` instead of `app/`? |
+| 3 | Gemini 60 s backoff on `ResourceExhausted` | What is the TS equivalent error detection? What's the unit test that injects the 429 and asserts the delay? |
+| 4 | Chroma access goes through the FastAPI wrapper | Does the wrapper stay (see §12)? If not, what replaces invariant #4 — a single `lib/chroma.ts` module that everything imports, forbidding direct `chromadb` client usage (which has no Node equivalent anyway)? |
+| 5 | Image normalization before hashing or Gemini | Which Node image lib? Which tests cover WMF, EMF, PNG-with-palette, RGBA? |
+| 6 | `chroma/` vector data is not to be cleaned | Does v2 relocate the data directory out of the repo (long-planned; §10.5 in INVARIANTS)? If yes, this is the time. |
+| 7 | Group-shape recursion | TS analog of the `MSO_SHAPE_TYPE.GROUP` walk. See 4.6. |
+| 8 | Consent gate (IRB) | See §9. |
+| 9 | Branches are a pipeline, not a landscape | Does the Next.js code live on `nextjs-impl` (existing), a new `refactor/nextjs-migration` (this branch), or does it eventually become `main`? Either way, update `BRANCHING.md`. |
+| 10 | Tech-debt gaps (secrets, firewall, no CI, drift) | Which gaps does v2 close by construction (e.g., ditching systemd closes 10.8), and which do we carry forward? |
+| 11 | Configuration of record | Nginx, systemd, and shell scripts must land in repo. Does v2 replace them with a `Dockerfile` + compose / Cloud Run YAML that we commit? |
+
+---
+
+## 9. Consent Gate (IRB)
+
+Invariant #8 is non-negotiable on the `Aggrement` branch. The Streamlit gate is a blocking full-page form that writes to `consent_responses.csv` on the VM before any upload UI renders.
+
+9.1. Does v2 ship with the IRB consent gate from day 1? If yes, where does it live:
+- Middleware at `src/middleware.ts` redirecting to `/consent` until a `consent_ok=...` cookie is set.
+- A server component wrapper at `src/app/(consented)/layout.tsx`.
+- A client-side modal (bad — bypassable).
+
+9.2. Where is the consent record persisted?
+- Flat CSV (matches current) on the host — brittle in multi-node.
+- DB table `consent_events` (timestamp, user-pseudonym, deck hash).
+- Append-only file in a GCS bucket.
+
+9.3. What's the data contract with the IRB? We need the exact list of fields to store and the data-retention horizon in writing before we swap storage mechanisms.
+
+9.4. Do we version the consent wording? If consent language changes, do previously-consented users re-consent?
+
+9.5. Consent flow under auth (section 10) — is consent per-account (one-time) or per-session (every visit)?
+
+---
+
+## 10. Auth & Identity
+
+Streamlit has no auth — anyone with the URL can use it. The GCP firewall also exposes ports 8001 and 8501 publicly (invariant #10.4). A Next.js migration is the natural point to add auth.
+
+10.1. Do we gate the app with auth in v2? If yes:
+- SUNY SSO (Brockport LDAP / CAS / Microsoft Entra)?
+- Google Workspace login via NextAuth / Auth.js?
+- Passwordless email link?
+- None (matches current)?
+
+10.2. If no auth, what's the abuse story for the publicly reachable Gemini-cost-bearing endpoints? (Today, nothing; this has not yet bitten because of obscurity.)
+
+10.3. If we add auth, how does it interact with IRB consent (§9)? Does a logged-in user skip consent once they've accepted once, or does every session re-prompt?
+
+10.4. Session storage: Auth.js JWT, database session, or iron-session cookies? Impact on 6.x state decisions.
+
+10.5. Does the download URL for the accessible deck require a signed session, or is a short-lived unguessable URL sufficient?
+
+---
+
+## 11. Production Deployment
+
+The live environment is bare-metal Python on systemd, behind nginx + certbot, on a single `e2-medium` Debian VM. The documented-but-unused Docker stack is in `Prod-v1`. Neither of these is a Next.js host. Answer before picking a hosting plan.
+
+11.1. What is the **target runtime** for the Next.js app?
+- **Vercel** — easy, great DX, pricing unclear at our scale, loss of control over timeouts and file-system persistence, hard to self-host Chroma alongside.
+- **Self-host Node on the existing VM** under a new systemd unit — minimal new infra, keeps Chroma co-located, but fights Next.js's strengths and inherits all the drift in §11 of INVARIANTS.
+- **Docker on the existing VM** — finally uses the Docker work sunk into `Prod-v1`, pairs naturally with a compose file that also runs the Chroma service.
+- **Google Cloud Run** — managed, scales, pairs with Secret Manager and GCS, requires a move off `chroma/` on local disk.
+- **GKE** — overkill for the current traffic.
+
+11.2. If Vercel: where does Chroma live? Vercel has no persistent file system; Chroma either moves to a managed DB (Pinecone, Weaviate Cloud, Chroma Cloud, pgvector on Supabase) or to a separate container that Vercel calls. Which?
+
+11.3. If self-host / Docker-on-VM: do we also finally add a second VM + load balancer, or accept the single-VM SPOF (invariant #10.7)?
+
+11.4. TLS termination — nginx + certbot stays, or we move to Caddy (as `Prod-v1` intended), or a managed LB terminates TLS?
+
+11.5. Process model:
+- Single Next.js server (`next start`) — simple.
+- Next.js standalone output + reverse proxy — smaller container.
+- Next.js on a platform (Vercel / Cloud Run) — no process model to manage.
+
+11.6. Environment variables: today it's a plaintext `.env` on the VM. Target:
+- `.env.production` file + systemd `EnvironmentFile=` (minor upgrade, same risk).
+- GCP Secret Manager + workload identity (closes invariant §10.1).
+- `.env` managed by the hosting platform (Vercel / Cloud Run).
+
+11.7. Logging & observability: today, `journalctl -u` on the VM. Target stack? (Cloud Logging, Datadog, Grafana + Loki, none for v1.)
+
+11.8. What replaces the existing `start_scripts/` shell scripts (currently on-VM-only, per invariant §10.3)? They must be committed to this repo before we cut over.
+
+11.9. Domain: stays `access.brockportsigai.org`. Does `/accessibility` path stay, or does the App Router get a cleaner `/`? nginx reverse-proxy config is the gatekeeper regardless; that config must land in repo (invariant #11).
+
+---
+
+## 12. Coexistence with the Chroma Service
+
+The Python FastAPI wrapper at `app/chroma-api/app.py` is invariant #4's reason for existing (decouples Streamlit from the `chromadb` Python package). The Next.js scaffold's `src/lib/chroma.ts` already talks to it via HTTP.
+
+12.1. Do we **keep** the FastAPI wrapper as-is and have Next.js speak HTTP to it? Pros: invariant #4 survives; zero Python-side change. Cons: we drag the Python runtime forward forever.
+
+12.2. Do we **port the wrapper to TypeScript** (a `src/app/api/chroma/**/route.ts` layer over the Chroma server directly or via `chromadb`'s JS client, if we trust it)? Pros: one language. Cons: we own one more thing to maintain; the JS Chroma client is younger than the Python one.
+
+12.3. Do we **replace Chroma** entirely for v2 (pgvector on Postgres, or Supabase vector, or Pinecone)? This also answers invariant #6 (the `chroma/` data dir problem) by construction.
+
+12.4. Migration: can an existing Chroma collection on prod be read by the new stack on day 1 of cutover, or do we require re-indexing from uploaded decks? If the former, coordinate with §14. If the latter, accept the one-time Gemini cost of re-embedding.
+
+12.5. Embedding function parity: what model does ChromaDB use today (default `all-MiniLM-L6-v2` via SentenceTransformers?), and what does the TS port use? If they differ, old vectors and new queries live in different spaces — incoherent. This is the single biggest footgun in this section.
+
+12.6. If the wrapper survives, do we extend invariant #4 to say "TS code must also go through the wrapper, never via direct `chromadb` JS client"?
+
+---
+
+## 13. Existing `nextjs-impl` Scaffold Audit
+
+The `nextjs-impl` branch already has a Next.js 16 + React 19 + Tailwind 4 + App Router scaffold with one route handler, one page, three lib modules, and the Python app moved under `backups/python-legacy/`. Before we write more on this branch, inventory what we keep.
+
+13.1. `package.json` — keep Next 16.2.3 / React 19.2.4, or pin to the latest LTS minor at migration start? What's our policy on `caret` vs. exact versions (the scaffold uses caret)?
+
+13.2. `src/app/layout.tsx` and global CSS — keep the current "dark + purple gradient" visual direction or redesign against a Brockport / accessibility-brand-compliant palette? (The tool is for accessibility; low contrast on a dark gradient is self-defeating.)
+
+13.3. `src/app/page.tsx` — single client component with hard-coded mock review cards and a `setTimeout(() => setStage('review'), 2000)` fake transition. **Keep as reference only** and rebuild per §2? **Keep and iterate**? **Delete**?
+
+13.4. `src/app/api/process/route.ts` — returns a hand-assembled `presentation` object derived from `PptxProcessor`. It does **no** Gemini, **no** Chroma, **no** alt-text write, **no** rebuild. Is this the spine we extend or a stub we throw away?
+
+13.5. `src/lib/pptx-utils.ts` — the critical file per §4. Line 146's `updateAltText` is a `console.log` stub. Do we extend this file or start over with a deliberate API (`parse`, `rebuild`, `writeAltText`)?
+
+13.6. `src/lib/gemini.ts` — has **no retry**, **no backoff**, **no image-normalization**. Would ship a direct regression of invariants #3 and #5. When do we fix it (before using it, obviously — but is that part of §5 or a prereq)?
+
+13.7. `src/lib/chroma.ts` — `axios.post(...)` wrapper around the existing FastAPI service. Stays or evolves per §12 answer.
+
+13.8. `backups/python-legacy/` — is that the **archive of record**, or do we keep the Python code live at `app/` during the transition and only move it to `backups/` at cutover?
+
+13.9. `AGENTS.md` on that branch says "This is NOT the Next.js you know … Read the relevant guide in `node_modules/next/dist/docs/` before writing any code." Do we formalize that as a cross-branch rule on `refactor/nextjs-migration` too?
+
+13.10. `CLAUDE.md` on that branch — inspect and decide whether it becomes part of our `AGENTS.md` lineage or gets deleted.
+
+13.11. Does this branch start from `nextjs-impl` (cherry-pick or merge) or from `main` / `feature/agent-ops-framework` and re-bootstrap Next.js? Answer determines whether we inherit the scaffold's early mistakes.
+
+---
+
+## 14. Cutover, Rollback, Data Migration
+
+14.1. Cutover mechanics: DNS flip of `access.brockportsigai.org`, nginx location swap (`/accessibility` → Next.js), dual-run with a kill switch, or a hard cut at a specific time?
+
+14.2. What's the acceptance criterion for "v2 is ready"? List every user-visible feature from §4 of `docs/PROJECT_OVERVIEW.md` and mark green/red before flip.
+
+14.3. Data to migrate (or not):
+- Chroma collections on the VM — probably discardable (§12.4).
+- `consent_responses.csv` — must migrate or be archived per IRB (§9.2).
+- Uploaded decks in `/tmp` — discardable.
+
+14.4. Rollback procedure — during v2's first 72 hours, what brings us back to Streamlit? Existing `docs/ops/SOP_ROLLBACK.md` assumes a git-based Python rollback on the VM. Rewrite for the Next.js host choice from §11.
+
+14.5. Communication plan: who gets notified of the cutover, and on what channel?
+
+14.6. Do we keep Streamlit **frozen and running** on port 8501 behind a feature-flagged nginx block for 30 days post-cutover, so we can re-expose it if v2 fails in production ways we didn't catch in staging?
+
+---
+
+## 15. Testing, Accessibility QA, Observability
+
+15.1. What are the test layers?
+- **Unit** (Vitest / Jest): zod schema, order_number invariant, alt-text XML writer round-trip, Gemini backoff, image normalization branches.
+- **Integration** (Playwright + MSW or real Chroma-dev): upload → describe → download.
+- **Fixture-based PPTX round-trip**: one real deck per invariant. Which decks do we commit as fixtures?
+- **Accessibility QA**: do we run PowerPoint Accessibility Checker on the output deck in CI? There is no headless CLI — what's the plan?
+
+15.2. Do we port `scripts/check_invariants.py` to TypeScript, or keep the Python script running in CI against the TS codebase? The regex-based checks mostly still apply but need path updates.
+
+15.3. Do we port `scripts/doctor.py`, `scripts/preflight.py`, `scripts/smoke_test.py` to equivalent Node scripts, or do we keep Python as the "ops language" and call `python` from npm scripts?
+
+15.4. What's the CI matrix? Today GitHub Actions runs `preflight.yml` on push/PR. For a Next.js app we also need:
+- `npm run lint`
+- `npm run build` (catches RSC / Client boundary errors)
+- `tsc --noEmit`
+- `playwright test`
+
+15.5. Observability — what logs, traces, and metrics do we emit from day 1? At minimum: Gemini call latency, Gemini retries, Chroma add/query latency, request duration per route, job success rate, job durations.
+
+15.6. Error reporting — Sentry, Google Error Reporting, or `console.error` + Cloud Logging?
+
+15.7. Load testing — what's the target concurrency and who runs the test before cutover?
+
+---
+
+## 16. Framework Integration
+
+This migration will outlive several agents. It must fit the ops framework already built.
+
+16.1. Does this work ship as a single giant PR, or as a sequence of PRs each using `docs/templates/REFACTOR.md` (and some `FEATURE.md`) against this branch?
+
+16.2. Which existing framework files need rewrites after the migration lands?
+- `docs/PROJECT_OVERVIEW.md` — the architecture diagram.
+- `docs/AGENT_CONTEXT.md` — file layout & conventions.
+- `docs/PRODUCTION_ENVIRONMENT.md` — new runtime & topology.
+- `docs/guardrails/INVARIANTS.md` — paths in every §Where; see §8 above.
+- `docs/guardrails/BRANCHING.md` — `nextjs-impl` reaches end-of-life.
+- `docs/ops/SOP_DEPLOY.md` — bare-metal → new deploy.
+- `docs/ops/SOP_ROLLBACK.md` — see §14.4.
+- `docs/ops/SOP_SECRETS.md` — key rotation steps for the new host.
+- `scripts/*` and `.github/workflows/preflight.yml` — see §15.
+
+16.3. Do we add new framework documents that this migration requires?
+- `docs/guardrails/NEXTJS_RULES.md` — RSC vs Client rules, Server Action payload caps, when to choose Route Handler vs Action, edge runtime forbidden.
+- `docs/ops/SOP_QUEUE.md` — if we adopt BullMQ / Cloud Tasks in §7.
+- `docs/refactor/NEXTJS_MIGRATION_DESIGN.md` — the successor to this document, post-review.
+
+16.4. When do we archive this file? When section 14 ships, this document becomes historical and should be moved to `docs/refactor/history/` with its answers inline.
+
+16.5. Who owns the refactor? A single reviewer for all PRs on this branch? `CODEOWNERS` update?
+
+---
+
+## 17. Open bets to make explicit
+
+The following are judgment calls that, once made, become implicit everywhere downstream. Make them on purpose.
+
+17.1. **Language monoculture vs. polyglot.** TypeScript-only or TypeScript + a Python sidecar (parsing / OCR / maybe Chroma wrapper). The polyglot path costs more ops but preserves python-pptx fidelity (see 4.1).
+
+17.2. **Runtime monoculture vs. platform.** Self-host vs. Vercel vs. Cloud Run. Affects §7 timeouts, §11 secrets, §12 Chroma, §15 observability.
+
+17.3. **State: cookies vs. database.** Adding Postgres is an infra escalation; not adding it pushes complexity into the URL and cookies.
+
+17.4. **RSC-first vs. Client-first.** Existing scaffold is client-first; §2 recommends RSC-first. Commit to one.
+
+17.5. **Auth now vs. never.** §10 — adding auth now closes §10.4 of INVARIANTS forever; not adding it preserves the current UX and obscurity-based security.
+
+17.6. **Re-index vs. carry vectors forward.** §12.4 — deletes prod Chroma data and re-embeds vs. wire-compatible migration.
+
+---
+
+## 18. Halt
+
+This document ends here. Do not start writing Next.js code until every section has an owner and an answer. The next document on this branch is `docs/refactor/NEXTJS_MIGRATION_DESIGN.md`, which is produced by answering the questions above.


### PR DESCRIPTION
## Summary
- Adds the finalized Next.js migration design as the implementation blueprint.
- Adds the preflight checklist that records the migration questions and constraints.
- Keeps this PR documentation-only so implementation can proceed in separate issue branches.

## Test plan
- Not run; docs-only change.
- Verified branch diff contains only `docs/refactor/NEXTJS_MIGRATION_DESIGN.md` and `docs/refactor/NEXTJS_MIGRATION_PREFLIGHT.md`.