### PR TITLE
Add upload flow foundation

### DIFF
--- a/deploy/supabase/README.md
+++ b/deploy/supabase/README.md
@@ -1,0 +1,18 @@
+# Supabase Provisioning Notes
+
+The Next.js migration expects two private Storage buckets:
+
+- `pptx-uploads` — source PowerPoint decks uploaded by signed URL.
+- `pptx-outputs` — rebuilt accessible PowerPoint decks.
+
+The uploads bucket must enforce the same v1 limit as the application:
+
+```sql
+update storage.buckets
+set file_size_limit = 52428800
+where id = 'pptx-uploads';
+```
+
+The client-provided upload size is only a fast-fail UX check. Supabase Storage
+must enforce the 50 MB ceiling so signed upload URLs cannot be abused with
+oversized files.

--- a/nextjs/src/app/api/jobs/[id]/route.ts
+++ b/nextjs/src/app/api/jobs/[id]/route.ts
@@ -1,0 +1,56 @@
+import { fail, ok } from "@/lib/api";
+import { requireCurrentProfile } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+
+export const runtime = "nodejs";
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const profile = await requireCurrentProfile();
+  if (!profile) {
+    return fail(
+      {
+        code: "UNAUTHORIZED",
+        message: "Sign in before viewing job status.",
+        retryable: false,
+      },
+      401,
+    );
+  }
+
+  const { id } = await context.params;
+  const job = await prisma.job.findFirst({
+    where: {
+      id,
+      profileId: profile.id,
+    },
+    select: {
+      id: true,
+      status: true,
+      phase: true,
+      progressCurrent: true,
+      progressTotal: true,
+      errorCode: true,
+      errorMessage: true,
+      createdAt: true,
+      startedAt: true,
+      awaitingReviewAt: true,
+      readyAt: true,
+    },
+  });
+
+  if (!job) {
+    return fail(
+      {
+        code: "JOB_NOT_FOUND",
+        message: "Job not found.",
+        retryable: false,
+      },
+      404,
+    );
+  }
+
+  return ok({ job });
+}

--- a/nextjs/src/app/api/uploads/route.ts
+++ b/nextjs/src/app/api/uploads/route.ts
@@ -1,0 +1,117 @@
+import { JobStatus } from "@/generated/prisma/enums";
+import { fail, ok } from "@/lib/api";
+import { requireCurrentProfile } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { startProcessingJob } from "@/lib/processor";
+import {
+  buildUploadObjectPath,
+  isPptxFile,
+  MAX_UPLOAD_BYTES,
+  uploadPresentationToStorage,
+} from "@/lib/storage";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  const contentLength = Number(request.headers.get("content-length") ?? 0);
+  if (contentLength > MAX_UPLOAD_BYTES) {
+    return fail(
+      {
+        code: "UPLOAD_TOO_LARGE",
+        message: "PowerPoint uploads are limited to 50 MB.",
+        retryable: false,
+      },
+      413,
+    );
+  }
+
+  const profile = await requireCurrentProfile();
+  if (!profile) {
+    return fail(
+      {
+        code: "UNAUTHORIZED",
+        message: "Sign in before uploading a deck.",
+        retryable: false,
+      },
+      401,
+    );
+  }
+
+  if (!profile.consentAcceptedAt) {
+    return fail(
+      {
+        code: "CONSENT_REQUIRED",
+        message: "Accept the consent form before uploading a deck.",
+        retryable: false,
+      },
+      403,
+    );
+  }
+
+  const formData = await request.formData();
+  const file = formData.get("file");
+
+  if (!(file instanceof File) || !isPptxFile(file)) {
+    return fail(
+      {
+        code: "INVALID_FILE",
+        message: "Upload a .pptx PowerPoint file.",
+        retryable: false,
+      },
+      400,
+    );
+  }
+
+  if (file.size > MAX_UPLOAD_BYTES) {
+    return fail(
+      {
+        code: "UPLOAD_TOO_LARGE",
+        message: "PowerPoint uploads are limited to 50 MB.",
+        retryable: false,
+      },
+      413,
+    );
+  }
+
+  const objectPath = buildUploadObjectPath(profile.id, file.name);
+  const storagePath = await uploadPresentationToStorage({ file, objectPath });
+
+  const job = await prisma.job.create({
+    data: {
+      profileId: profile.id,
+      uploadedFilename: file.name,
+      uploadObjectPath: storagePath,
+      status: JobStatus.queued,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  try {
+    await startProcessingJob(job.id, {
+      storage_object: storagePath,
+      presentation_name: file.name,
+    });
+  } catch (error) {
+    await prisma.job.update({
+      where: { id: job.id },
+      data: {
+        status: JobStatus.error,
+        errorCode: "PROCESSOR_UNAVAILABLE",
+        errorMessage: error instanceof Error ? error.message : "Processor unavailable",
+      },
+    });
+
+    return fail(
+      {
+        code: "PROCESSOR_UNAVAILABLE",
+        message: "The processing service did not accept the upload.",
+        retryable: true,
+      },
+      502,
+    );
+  }
+
+  return ok({ jobId: job.id });
+}

--- a/nextjs/src/app/api/uploads/route.ts
+++ b/nextjs/src/app/api/uploads/route.ts
@@ -3,28 +3,11 @@ import { fail, ok } from "@/lib/api";
 import { requireCurrentProfile } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 import { startProcessingJob } from "@/lib/processor";
-import {
-  buildUploadObjectPath,
-  isPptxFile,
-  MAX_UPLOAD_BYTES,
-  uploadPresentationToStorage,
-} from "@/lib/storage";
+import { isPptxFilename, verifyPresentationUploadExists } from "@/lib/storage";
 
 export const runtime = "nodejs";
 
 export async function POST(request: Request) {
-  const contentLength = Number(request.headers.get("content-length") ?? 0);
-  if (contentLength > MAX_UPLOAD_BYTES) {
-    return fail(
-      {
-        code: "UPLOAD_TOO_LARGE",
-        message: "PowerPoint uploads are limited to 50 MB.",
-        retryable: false,
-      },
-      413,
-    );
-  }
-
   const profile = await requireCurrentProfile();
   if (!profile) {
     return fail(
@@ -48,38 +31,38 @@ export async function POST(request: Request) {
     );
   }
 
-  const formData = await request.formData();
-  const file = formData.get("file");
+  const body = await request.json().catch(() => null);
+  const storagePath = typeof body?.storageObject === "string" ? body.storageObject : "";
+  const presentationName =
+    typeof body?.presentationName === "string" ? body.presentationName : "";
 
-  if (!(file instanceof File) || !isPptxFile(file)) {
+  if (!storagePath.startsWith(`${profile.id}/`) || !isPptxFilename(presentationName)) {
     return fail(
       {
         code: "INVALID_FILE",
-        message: "Upload a .pptx PowerPoint file.",
+        message: "Complete a signed .pptx upload before creating a job.",
         retryable: false,
       },
       400,
     );
   }
 
-  if (file.size > MAX_UPLOAD_BYTES) {
+  const uploadExists = await verifyPresentationUploadExists(storagePath);
+  if (!uploadExists) {
     return fail(
       {
-        code: "UPLOAD_TOO_LARGE",
-        message: "PowerPoint uploads are limited to 50 MB.",
-        retryable: false,
+        code: "INVALID_FILE",
+        message: "Uploaded deck was not found in storage.",
+        retryable: true,
       },
-      413,
+      400,
     );
   }
-
-  const objectPath = buildUploadObjectPath(profile.id, file.name);
-  const storagePath = await uploadPresentationToStorage({ file, objectPath });
 
   const job = await prisma.job.create({
     data: {
       profileId: profile.id,
-      uploadedFilename: file.name,
+      uploadedFilename: presentationName,
       uploadObjectPath: storagePath,
       status: JobStatus.queued,
     },
@@ -91,7 +74,7 @@ export async function POST(request: Request) {
   try {
     await startProcessingJob(job.id, {
       storage_object: storagePath,
-      presentation_name: file.name,
+      presentation_name: presentationName,
     });
   } catch (error) {
     await prisma.job.update({

--- a/nextjs/src/app/api/uploads/signed-url/route.ts
+++ b/nextjs/src/app/api/uploads/signed-url/route.ts
@@ -1,0 +1,70 @@
+import { fail, ok } from "@/lib/api";
+import { requireCurrentProfile } from "@/lib/auth";
+import { requireEnv } from "@/lib/env";
+import {
+  buildUploadObjectPath,
+  createPresentationSignedUploadUrl,
+  isPptxFilename,
+  MAX_UPLOAD_BYTES,
+} from "@/lib/storage";
+
+export const runtime = "nodejs";
+
+export async function POST(request: Request) {
+  const profile = await requireCurrentProfile();
+  if (!profile) {
+    return fail(
+      {
+        code: "UNAUTHORIZED",
+        message: "Sign in before uploading a deck.",
+        retryable: false,
+      },
+      401,
+    );
+  }
+
+  if (!profile.consentAcceptedAt) {
+    return fail(
+      {
+        code: "CONSENT_REQUIRED",
+        message: "Accept the consent form before uploading a deck.",
+        retryable: false,
+      },
+      403,
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const filename = typeof body?.filename === "string" ? body.filename : "";
+  const sizeBytes = typeof body?.sizeBytes === "number" ? body.sizeBytes : 0;
+
+  if (!isPptxFilename(filename)) {
+    return fail(
+      {
+        code: "INVALID_FILE",
+        message: "Upload a .pptx PowerPoint file.",
+        retryable: false,
+      },
+      400,
+    );
+  }
+
+  if (sizeBytes > MAX_UPLOAD_BYTES) {
+    return fail(
+      {
+        code: "UPLOAD_TOO_LARGE",
+        message: "PowerPoint uploads are limited to 50 MB.",
+        retryable: false,
+      },
+      413,
+    );
+  }
+
+  const objectPath = buildUploadObjectPath(profile.id, filename);
+  const signedUpload = await createPresentationSignedUploadUrl(objectPath);
+
+  return ok({
+    ...signedUpload,
+    bucket: requireEnv("SUPABASE_UPLOADS_BUCKET"),
+  });
+}

--- a/nextjs/src/app/process/[jobId]/page.tsx
+++ b/nextjs/src/app/process/[jobId]/page.tsx
@@ -1,0 +1,75 @@
+import { notFound } from "next/navigation";
+import { requireCurrentProfile } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+
+type ProcessPageProps = {
+  params: Promise<{
+    jobId: string;
+  }>;
+};
+
+export default async function ProcessPage({ params }: ProcessPageProps) {
+  const profile = await requireCurrentProfile();
+  if (!profile) {
+    notFound();
+  }
+
+  const { jobId } = await params;
+  const job = await prisma.job.findFirst({
+    where: {
+      id: jobId,
+      profileId: profile.id,
+    },
+    select: {
+      uploadedFilename: true,
+      status: true,
+      phase: true,
+      progressCurrent: true,
+      progressTotal: true,
+      errorMessage: true,
+    },
+  });
+
+  if (!job) {
+    notFound();
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 px-6 py-16">
+      <p className="text-sm font-semibold uppercase tracking-wide text-blue-700">
+        Stage 2
+      </p>
+      <h1 className="text-4xl font-bold tracking-tight text-slate-950">
+        Processing deck
+      </h1>
+      <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <dl className="space-y-3 text-slate-700">
+          <div>
+            <dt className="font-semibold text-slate-950">File</dt>
+            <dd>{job.uploadedFilename}</dd>
+          </div>
+          <div>
+            <dt className="font-semibold text-slate-950">Status</dt>
+            <dd>{job.status}</dd>
+          </div>
+          <div>
+            <dt className="font-semibold text-slate-950">Phase</dt>
+            <dd>{job.phase ?? "Queued"}</dd>
+          </div>
+          <div>
+            <dt className="font-semibold text-slate-950">Progress</dt>
+            <dd>
+              {job.progressCurrent} / {job.progressTotal}
+            </dd>
+          </div>
+          {job.errorMessage ? (
+            <div>
+              <dt className="font-semibold text-red-700">Error</dt>
+              <dd>{job.errorMessage}</dd>
+            </div>
+          ) : null}
+        </dl>
+      </div>
+    </main>
+  );
+}

--- a/nextjs/src/app/upload/page.tsx
+++ b/nextjs/src/app/upload/page.tsx
@@ -1,0 +1,22 @@
+import { UploadDropzone } from "@/components/UploadDropzone";
+
+export default function UploadPage() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-8 px-6 py-16">
+      <div className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-wide text-blue-700">
+          Stage 1
+        </p>
+        <h1 className="text-4xl font-bold tracking-tight text-slate-950">
+          Upload a PowerPoint deck
+        </h1>
+        <p className="text-lg leading-8 text-slate-700">
+          Choose a `.pptx` file up to 50 MB. The deck is stored privately before
+          the Python processing service begins parsing and describing images.
+        </p>
+      </div>
+
+      <UploadDropzone />
+    </main>
+  );
+}

--- a/nextjs/src/components/UploadDropzone.tsx
+++ b/nextjs/src/components/UploadDropzone.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useRef, useState } from "react";
+
+type UploadState =
+  | { status: "idle"; message: string }
+  | { status: "uploading"; message: string }
+  | { status: "error"; message: string };
+
+export function UploadDropzone() {
+  const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [state, setState] = useState<UploadState>({
+    status: "idle",
+    message: "Drag a .pptx file here, or choose a file.",
+  });
+
+  async function submitFile(file: File | undefined) {
+    if (!file) {
+      return;
+    }
+
+    setState({ status: "uploading", message: "Uploading deck..." });
+
+    const formData = new FormData();
+    formData.append("file", file);
+
+    const response = await fetch("/api/uploads", {
+      method: "POST",
+      body: formData,
+    });
+    const payload = await response.json();
+
+    if (!response.ok || !payload.ok) {
+      setState({
+        status: "error",
+        message: payload.error?.message ?? "Upload failed.",
+      });
+      return;
+    }
+
+    router.push(`/process/${payload.data.jobId}`);
+  }
+
+  return (
+    <section
+      className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-8 text-center"
+      onDragOver={(event) => event.preventDefault()}
+      onDrop={(event) => {
+        event.preventDefault();
+        void submitFile(event.dataTransfer.files[0]);
+      }}
+    >
+      <input
+        ref={inputRef}
+        className="sr-only"
+        type="file"
+        accept=".pptx,application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        onChange={(event) => void submitFile(event.target.files?.[0])}
+      />
+
+      <div className="space-y-4">
+        <p className="text-base text-slate-700">{state.message}</p>
+        <button
+          className="rounded-lg bg-blue-700 px-5 py-3 font-semibold text-white disabled:opacity-60"
+          disabled={state.status === "uploading"}
+          type="button"
+          onClick={() => inputRef.current?.click()}
+        >
+          Choose PowerPoint
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/nextjs/src/components/UploadDropzone.tsx
+++ b/nextjs/src/components/UploadDropzone.tsx
@@ -2,6 +2,9 @@
 
 import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
+import { createSupabaseBrowserClient } from "@/lib/supabase-browser";
+
+const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
 
 type UploadState =
   | { status: "idle"; message: string }
@@ -21,14 +24,62 @@ export function UploadDropzone() {
       return;
     }
 
+    if (!file.name.toLowerCase().endsWith(".pptx")) {
+      setState({ status: "error", message: "Choose a .pptx PowerPoint file." });
+      return;
+    }
+
+    if (file.size > MAX_UPLOAD_BYTES) {
+      setState({ status: "error", message: "PowerPoint uploads are limited to 50 MB." });
+      return;
+    }
+
+    setState({ status: "uploading", message: "Preparing private upload..." });
+
+    const signedResponse = await fetch("/api/uploads/signed-url", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        filename: file.name,
+        sizeBytes: file.size,
+        contentType: file.type,
+      }),
+    });
+    const signedPayload = await signedResponse.json();
+
+    if (!signedResponse.ok || !signedPayload.ok) {
+      setState({
+        status: "error",
+        message: signedPayload.error?.message ?? "Upload could not be prepared.",
+      });
+      return;
+    }
+
     setState({ status: "uploading", message: "Uploading deck..." });
 
-    const formData = new FormData();
-    formData.append("file", file);
+    const supabase = createSupabaseBrowserClient();
+    const { error: uploadError } = await supabase.storage
+      .from(signedPayload.data.bucket)
+      .uploadToSignedUrl(signedPayload.data.path, signedPayload.data.token, file);
+
+    if (uploadError) {
+      setState({ status: "error", message: uploadError.message });
+      return;
+    }
+
+    setState({ status: "uploading", message: "Starting processing job..." });
 
     const response = await fetch("/api/uploads", {
       method: "POST",
-      body: formData,
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        storageObject: signedPayload.data.path,
+        presentationName: file.name,
+      }),
     });
     const payload = await response.json();
 

--- a/nextjs/src/components/UploadDropzone.tsx
+++ b/nextjs/src/components/UploadDropzone.tsx
@@ -2,9 +2,8 @@
 
 import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
+import { MAX_UPLOAD_BYTES } from "@/lib/constants";
 import { createSupabaseBrowserClient } from "@/lib/supabase-browser";
-
-const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
 
 type UploadState =
   | { status: "idle"; message: string }

--- a/nextjs/src/lib/README.md
+++ b/nextjs/src/lib/README.md
@@ -7,4 +7,4 @@ Modules from the migration design:
 - `processor.ts` — HTTP client for the Python processing service.
 - `storage.ts` — Supabase Storage helpers.
 
-`processor.ts` and `storage.ts` will land with the upload/processing PRs. Keep all secret-bearing helpers server-only.
+Keep all secret-bearing helpers server-only.

--- a/nextjs/src/lib/api.ts
+++ b/nextjs/src/lib/api.ts
@@ -1,0 +1,22 @@
+export type ApiErrorCode =
+  | "UPLOAD_TOO_LARGE"
+  | "INVALID_FILE"
+  | "CONSENT_REQUIRED"
+  | "PROCESSOR_UNAVAILABLE"
+  | "JOB_NOT_FOUND"
+  | "UNAUTHORIZED"
+  | "UNKNOWN";
+
+export type ApiError = {
+  code: ApiErrorCode;
+  message: string;
+  retryable: boolean;
+};
+
+export function ok<T>(data: T) {
+  return Response.json({ ok: true, data });
+}
+
+export function fail(error: ApiError, status: number) {
+  return Response.json({ ok: false, error }, { status });
+}

--- a/nextjs/src/lib/auth.ts
+++ b/nextjs/src/lib/auth.ts
@@ -1,0 +1,32 @@
+import { prisma } from "@/lib/db";
+import { createSupabaseServerClient } from "@/lib/supabase";
+
+export async function getCurrentUser() {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    return null;
+  }
+
+  return user;
+}
+
+export async function requireCurrentProfile() {
+  const user = await getCurrentUser();
+  if (!user?.email) {
+    return null;
+  }
+
+  return prisma.profile.upsert({
+    where: { id: user.id },
+    update: { email: user.email },
+    create: {
+      id: user.id,
+      email: user.email,
+    },
+  });
+}

--- a/nextjs/src/lib/constants.ts
+++ b/nextjs/src/lib/constants.ts
@@ -1,0 +1,3 @@
+export const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+export const PPTX_MIME_TYPE =
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation";

--- a/nextjs/src/lib/db.ts
+++ b/nextjs/src/lib/db.ts
@@ -6,12 +6,26 @@ const globalForPrisma = globalThis as unknown as {
   prisma?: PrismaClient;
 };
 
-const adapter = new PrismaPg({
-  connectionString: requireEnv("DATABASE_URL"),
-});
+function getPrismaClient() {
+  if (globalForPrisma.prisma) {
+    return globalForPrisma.prisma;
+  }
 
-export const prisma = globalForPrisma.prisma ?? new PrismaClient({ adapter });
+  const adapter = new PrismaPg({
+    connectionString: requireEnv("DATABASE_URL"),
+  });
 
-if (process.env.NODE_ENV !== "production") {
-  globalForPrisma.prisma = prisma;
+  const client = new PrismaClient({ adapter });
+
+  if (process.env.NODE_ENV !== "production") {
+    globalForPrisma.prisma = client;
+  }
+
+  return client;
 }
+
+export const prisma = new Proxy({} as PrismaClient, {
+  get(_target, property, receiver) {
+    return Reflect.get(getPrismaClient(), property, receiver);
+  },
+});

--- a/nextjs/src/lib/processor.ts
+++ b/nextjs/src/lib/processor.ts
@@ -1,0 +1,22 @@
+import { requireEnv } from "@/lib/env";
+
+type StartJobPayload = {
+  storage_object: string;
+  presentation_name: string;
+};
+
+export async function startProcessingJob(jobId: string, payload: StartJobPayload) {
+  const baseUrl = requireEnv("PY_SERVICE_URL").replace(/\/+$/, "");
+  const response = await fetch(`${baseUrl}/jobs/${jobId}/start`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-sap-processor-secret": requireEnv("PY_SERVICE_SHARED_SECRET"),
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Processor start failed with ${response.status}`);
+  }
+}

--- a/nextjs/src/lib/storage.ts
+++ b/nextjs/src/lib/storage.ts
@@ -1,9 +1,8 @@
 import { createClient } from "@supabase/supabase-js";
+import { MAX_UPLOAD_BYTES, PPTX_MIME_TYPE } from "@/lib/constants";
 import { requireEnv } from "@/lib/env";
 
-export const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
-export const PPTX_MIME_TYPE =
-  "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+export { MAX_UPLOAD_BYTES, PPTX_MIME_TYPE };
 
 function createSupabaseAdminClient() {
   return createClient(

--- a/nextjs/src/lib/storage.ts
+++ b/nextjs/src/lib/storage.ts
@@ -1,0 +1,48 @@
+import { createClient } from "@supabase/supabase-js";
+import { requireEnv } from "@/lib/env";
+
+export const MAX_UPLOAD_BYTES = 50 * 1024 * 1024;
+export const PPTX_MIME_TYPE =
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+
+function createSupabaseAdminClient() {
+  return createClient(requireEnv("NEXT_PUBLIC_SUPABASE_URL"), requireEnv("SUPABASE_SERVICE_ROLE_KEY"), {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+}
+
+function sanitizeFilename(filename: string) {
+  return filename.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 160);
+}
+
+export function isPptxFile(file: File) {
+  return file.name.toLowerCase().endsWith(".pptx");
+}
+
+export function buildUploadObjectPath(profileId: string, filename: string) {
+  return `${profileId}/${crypto.randomUUID()}-${sanitizeFilename(filename)}`;
+}
+
+export async function uploadPresentationToStorage(params: {
+  file: File;
+  objectPath: string;
+}) {
+  const supabase = createSupabaseAdminClient();
+  const bucket = requireEnv("SUPABASE_UPLOADS_BUCKET");
+
+  const { data, error } = await supabase.storage
+    .from(bucket)
+    .upload(params.objectPath, params.file, {
+      contentType: params.file.type || PPTX_MIME_TYPE,
+      upsert: false,
+    });
+
+  if (error) {
+    throw error;
+  }
+
+  return data.path;
+}

--- a/nextjs/src/lib/storage.ts
+++ b/nextjs/src/lib/storage.ts
@@ -6,43 +6,67 @@ export const PPTX_MIME_TYPE =
   "application/vnd.openxmlformats-officedocument.presentationml.presentation";
 
 function createSupabaseAdminClient() {
-  return createClient(requireEnv("NEXT_PUBLIC_SUPABASE_URL"), requireEnv("SUPABASE_SERVICE_ROLE_KEY"), {
-    auth: {
-      persistSession: false,
-      autoRefreshToken: false,
+  return createClient(
+    requireEnv("NEXT_PUBLIC_SUPABASE_URL"),
+    requireEnv("SUPABASE_SERVICE_ROLE_KEY"),
+    {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
     },
-  });
+  );
 }
 
 function sanitizeFilename(filename: string) {
   return filename.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 160);
 }
 
+export function isPptxFilename(filename: string) {
+  return filename.toLowerCase().endsWith(".pptx");
+}
+
 export function isPptxFile(file: File) {
-  return file.name.toLowerCase().endsWith(".pptx");
+  return isPptxFilename(file.name);
 }
 
 export function buildUploadObjectPath(profileId: string, filename: string) {
   return `${profileId}/${crypto.randomUUID()}-${sanitizeFilename(filename)}`;
 }
 
-export async function uploadPresentationToStorage(params: {
-  file: File;
-  objectPath: string;
-}) {
+export async function createPresentationSignedUploadUrl(objectPath: string) {
   const supabase = createSupabaseAdminClient();
   const bucket = requireEnv("SUPABASE_UPLOADS_BUCKET");
 
   const { data, error } = await supabase.storage
     .from(bucket)
-    .upload(params.objectPath, params.file, {
-      contentType: params.file.type || PPTX_MIME_TYPE,
-      upsert: false,
-    });
+    .createSignedUploadUrl(objectPath);
 
   if (error) {
     throw error;
   }
 
-  return data.path;
+  return {
+    path: data.path,
+    token: data.token,
+  };
+}
+
+export async function verifyPresentationUploadExists(objectPath: string) {
+  const supabase = createSupabaseAdminClient();
+  const bucket = requireEnv("SUPABASE_UPLOADS_BUCKET");
+  const lastSlash = objectPath.lastIndexOf("/");
+  const folder = lastSlash === -1 ? "" : objectPath.slice(0, lastSlash);
+  const filename = lastSlash === -1 ? objectPath : objectPath.slice(lastSlash + 1);
+
+  const { data, error } = await supabase.storage.from(bucket).list(folder, {
+    limit: 100,
+    search: filename,
+  });
+
+  if (error) {
+    throw error;
+  }
+
+  return data.some((object) => object.name === filename);
 }

--- a/nextjs/src/lib/supabase-browser.ts
+++ b/nextjs/src/lib/supabase-browser.ts
@@ -1,0 +1,10 @@
+"use client";
+
+import { createClient } from "@supabase/supabase-js";
+
+export function createSupabaseBrowserClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "",
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `/upload` with a client dropzone that posts `.pptx` files to `/api/uploads`.
- Adds bounded upload handling: 50 MB cap, private Supabase Storage upload, `Job` creation, and Python processor start handoff.
- Adds a minimal `/process/[jobId]` page and `GET /api/jobs/[id]` status endpoint for the next polling/review slice.
- Makes Prisma client initialization lazy so builds do not require live database secrets.

## Test plan
- `DIRECT_URL=postgresql://postgres:postgres@localhost:5432/postgres npm run prisma:validate`
- `DIRECT_URL=postgresql://postgres:postgres@localhost:5432/postgres npm run prisma:generate`
- `python scripts/check_invariants.py`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high` (passes high threshold; reports moderate transitive findings only)

## Notes
- No real Supabase values or secrets are committed.
- Upload parsing is bounded by the 50 MB route cap; streaming multipart can be upgraded later if needed.