### PR TITLE
Add review and commit flow

### DIFF
--- a/nextjs/src/app/api/jobs/[id]/commit/route.ts
+++ b/nextjs/src/app/api/jobs/[id]/commit/route.ts
@@ -1,0 +1,121 @@
+import { JobStatus } from "@/generated/prisma/enums";
+import { fail, ok } from "@/lib/api";
+import { requireCurrentProfile } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+import { commitProcessingJob } from "@/lib/processor";
+
+export const runtime = "nodejs";
+
+type CommitDescriptionInput = {
+  id?: string;
+  finalAltText?: string;
+};
+
+export async function POST(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const profile = await requireCurrentProfile();
+  if (!profile) {
+    return fail(
+      {
+        code: "UNAUTHORIZED",
+        message: "Sign in before committing descriptions.",
+        retryable: false,
+      },
+      401,
+    );
+  }
+
+  const { id } = await context.params;
+  const body = await request.json().catch(() => null);
+  const inputDescriptions = Array.isArray(body?.descriptions)
+    ? (body.descriptions as CommitDescriptionInput[])
+    : [];
+
+  const job = await prisma.job.findFirst({
+    where: {
+      id,
+      profileId: profile.id,
+    },
+    select: {
+      id: true,
+      uploadedFilename: true,
+      uploadObjectPath: true,
+      descriptions: true,
+    },
+  });
+
+  if (!job) {
+    return fail(
+      {
+        code: "JOB_NOT_FOUND",
+        message: "Job not found.",
+        retryable: false,
+      },
+      404,
+    );
+  }
+
+  const submittedTextById = new Map(
+    inputDescriptions
+      .filter((description) => description.id && description.finalAltText)
+      .map((description) => [description.id as string, description.finalAltText as string]),
+  );
+
+  const commitDescriptions = job.descriptions.map((description) => ({
+    id: description.id,
+    slideNumber: description.slideNumber,
+    orderNumber: description.orderNumber,
+    altText:
+      submittedTextById.get(description.id)?.trim() ??
+      description.finalAltText ??
+      description.aiDescription ??
+      "",
+  }));
+
+  await prisma.$transaction([
+    ...commitDescriptions.map((description) =>
+      prisma.slideDescription.update({
+        where: { id: description.id },
+        data: { finalAltText: description.altText },
+      }),
+    ),
+    prisma.job.update({
+      where: { id: job.id },
+      data: {
+        status: JobStatus.rebuilding,
+        phase: "Rebuilding deck",
+        committedAt: new Date(),
+      },
+    }),
+  ]);
+
+  try {
+    await commitProcessingJob(job.id, {
+      storageObject: job.uploadObjectPath,
+      presentationName: job.uploadedFilename,
+      descriptions: commitDescriptions,
+    });
+  } catch (error) {
+    await prisma.job.update({
+      where: { id: job.id },
+      data: {
+        status: JobStatus.error,
+        errorCode: "REBUILD_FAILED",
+        errorMessage: error instanceof Error ? error.message : "Processor commit failed",
+      },
+    });
+
+    return fail(
+      {
+        code: "PROCESSOR_UNAVAILABLE",
+        message: "The processing service did not accept the rebuild request.",
+        retryable: true,
+      },
+      502,
+    );
+  }
+
+  return ok({ jobId: job.id });
+}

--- a/nextjs/src/app/api/jobs/[id]/descriptions/route.ts
+++ b/nextjs/src/app/api/jobs/[id]/descriptions/route.ts
@@ -13,7 +13,7 @@ export async function GET(
     return fail(
       {
         code: "UNAUTHORIZED",
-        message: "Sign in before viewing job status.",
+        message: "Sign in before viewing descriptions.",
         retryable: false,
       },
       401,
@@ -27,18 +27,9 @@ export async function GET(
       profileId: profile.id,
     },
     select: {
-      id: true,
-      status: true,
-      phase: true,
-      progressCurrent: true,
-      progressTotal: true,
-      outputObjectPath: true,
-      errorCode: true,
-      errorMessage: true,
-      createdAt: true,
-      startedAt: true,
-      awaitingReviewAt: true,
-      readyAt: true,
+      descriptions: {
+        orderBy: [{ slideNumber: "asc" }, { orderNumber: "asc" }],
+      },
     },
   });
 
@@ -53,5 +44,5 @@ export async function GET(
     );
   }
 
-  return ok({ job });
+  return ok({ descriptions: job.descriptions });
 }

--- a/nextjs/src/app/download/[jobId]/page.tsx
+++ b/nextjs/src/app/download/[jobId]/page.tsx
@@ -1,0 +1,55 @@
+import { notFound, redirect } from "next/navigation";
+import { requireCurrentProfile } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+
+type DownloadPageProps = {
+  params: Promise<{
+    jobId: string;
+  }>;
+};
+
+export default async function DownloadPage({ params }: DownloadPageProps) {
+  const profile = await requireCurrentProfile();
+  if (!profile) {
+    notFound();
+  }
+
+  const { jobId } = await params;
+  const job = await prisma.job.findFirst({
+    where: {
+      id: jobId,
+      profileId: profile.id,
+    },
+    select: {
+      uploadedFilename: true,
+      status: true,
+      outputObjectPath: true,
+    },
+  });
+
+  if (!job) {
+    notFound();
+  }
+
+  if (job.status !== "ready") {
+    redirect(`/process/${jobId}`);
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 px-6 py-16">
+      <p className="text-sm font-semibold uppercase tracking-wide text-blue-700">
+        Stage 4
+      </p>
+      <h1 className="text-4xl font-bold tracking-tight text-slate-950">
+        Accessible deck ready
+      </h1>
+      <p className="text-lg leading-8 text-slate-700">
+        `{job.uploadedFilename}` has been rebuilt. The signed download button
+        will be added in the download-flow slice.
+      </p>
+      <p className="rounded-lg bg-slate-100 p-4 font-mono text-sm text-slate-700">
+        {job.outputObjectPath}
+      </p>
+    </main>
+  );
+}

--- a/nextjs/src/app/process/[jobId]/page.tsx
+++ b/nextjs/src/app/process/[jobId]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { StatusPoller } from "@/components/StatusPoller";
 import { requireCurrentProfile } from "@/lib/auth";
 import { prisma } from "@/lib/db";
 
@@ -70,6 +71,7 @@ export default async function ProcessPage({ params }: ProcessPageProps) {
           ) : null}
         </dl>
       </div>
+      <StatusPoller jobId={jobId} />
     </main>
   );
 }

--- a/nextjs/src/app/review/[jobId]/page.tsx
+++ b/nextjs/src/app/review/[jobId]/page.tsx
@@ -1,0 +1,70 @@
+import { notFound, redirect } from "next/navigation";
+import { ReviewGrid } from "@/components/ReviewGrid";
+import { requireCurrentProfile } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+
+type ReviewPageProps = {
+  params: Promise<{
+    jobId: string;
+  }>;
+};
+
+export default async function ReviewPage({ params }: ReviewPageProps) {
+  const profile = await requireCurrentProfile();
+  if (!profile) {
+    notFound();
+  }
+
+  const { jobId } = await params;
+  const job = await prisma.job.findFirst({
+    where: {
+      id: jobId,
+      profileId: profile.id,
+    },
+    select: {
+      uploadedFilename: true,
+      status: true,
+      descriptions: {
+        orderBy: [{ slideNumber: "asc" }, { orderNumber: "asc" }],
+        select: {
+          id: true,
+          slideNumber: true,
+          orderNumber: true,
+          aiDescription: true,
+          finalAltText: true,
+        },
+      },
+    },
+  });
+
+  if (!job) {
+    notFound();
+  }
+
+  if (job.status === "ready") {
+    redirect(`/download/${jobId}`);
+  }
+
+  if (job.status !== "awaiting_review") {
+    redirect(`/process/${jobId}`);
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-4xl flex-col gap-8 px-6 py-16">
+      <div className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-wide text-blue-700">
+          Stage 3
+        </p>
+        <h1 className="text-4xl font-bold tracking-tight text-slate-950">
+          Review generated alt text
+        </h1>
+        <p className="text-lg leading-8 text-slate-700">
+          Review each image description for `{job.uploadedFilename}` before
+          exporting the accessible deck.
+        </p>
+      </div>
+
+      <ReviewGrid jobId={jobId} descriptions={job.descriptions} />
+    </main>
+  );
+}

--- a/nextjs/src/components/ReviewGrid.tsx
+++ b/nextjs/src/components/ReviewGrid.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+type ReviewDescription = {
+  id: string;
+  slideNumber: number;
+  orderNumber: number;
+  aiDescription: string | null;
+  finalAltText: string | null;
+};
+
+export function ReviewGrid({
+  jobId,
+  descriptions,
+}: {
+  jobId: string;
+  descriptions: ReviewDescription[];
+}) {
+  const router = useRouter();
+  const [drafts, setDrafts] = useState(
+    () =>
+      new Map(
+        descriptions.map((description) => [
+          description.id,
+          description.finalAltText ?? description.aiDescription ?? "",
+        ]),
+      ),
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function commitReview() {
+    setIsSubmitting(true);
+    setError(null);
+
+    const response = await fetch(`/api/jobs/${jobId}/commit`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        descriptions: Array.from(drafts.entries()).map(([id, finalAltText]) => ({
+          id,
+          finalAltText,
+        })),
+      }),
+    });
+    const payload = await response.json();
+
+    if (!response.ok || !payload.ok) {
+      setError(payload.error?.message ?? "Review could not be committed.");
+      setIsSubmitting(false);
+      return;
+    }
+
+    router.push(`/process/${jobId}`);
+  }
+
+  return (
+    <section className="space-y-6">
+      {descriptions.map((description) => (
+        <article
+          className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"
+          key={description.id}
+        >
+          <div className="mb-3 flex flex-wrap gap-3 text-sm font-semibold text-slate-600">
+            <span>Slide {description.slideNumber}</span>
+            <span>Order {description.orderNumber}</span>
+          </div>
+          <label className="block space-y-2">
+            <span className="font-semibold text-slate-950">Alt text</span>
+            <textarea
+              className="min-h-32 w-full rounded-lg border border-slate-300 p-3 text-slate-900"
+              value={drafts.get(description.id) ?? ""}
+              onChange={(event) => {
+                const nextDrafts = new Map(drafts);
+                nextDrafts.set(description.id, event.target.value);
+                setDrafts(nextDrafts);
+              }}
+            />
+          </label>
+        </article>
+      ))}
+
+      {error ? <p className="text-red-700">{error}</p> : null}
+
+      <button
+        className="rounded-lg bg-blue-700 px-5 py-3 font-semibold text-white disabled:opacity-60"
+        disabled={isSubmitting || descriptions.length === 0}
+        type="button"
+        onClick={() => void commitReview()}
+      >
+        Confirm & Export
+      </button>
+    </section>
+  );
+}

--- a/nextjs/src/components/StatusPoller.tsx
+++ b/nextjs/src/components/StatusPoller.tsx
@@ -17,6 +17,8 @@ export function StatusPoller({ jobId }: { jobId: string }) {
 
   useEffect(() => {
     let cancelled = false;
+    let timeoutId: number | undefined;
+    const startedAt = Date.now();
 
     async function poll() {
       const response = await fetch(`/api/jobs/${jobId}`, { cache: "no-store" });
@@ -32,15 +34,19 @@ export function StatusPoller({ jobId }: { jobId: string }) {
         router.push(`/review/${jobId}`);
       } else if (nextJob.status === "ready") {
         router.push(`/download/${jobId}`);
+      } else if (nextJob.status !== "error") {
+        const elapsedMs = Date.now() - startedAt;
+        timeoutId = window.setTimeout(() => void poll(), elapsedMs > 120000 ? 10000 : 5000);
       }
     }
 
     void poll();
-    const interval = window.setInterval(() => void poll(), 5000);
 
     return () => {
       cancelled = true;
-      window.clearInterval(interval);
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+      }
     };
   }, [jobId, router]);
 

--- a/nextjs/src/components/StatusPoller.tsx
+++ b/nextjs/src/components/StatusPoller.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+type JobStatusPayload = {
+  status: string;
+  phase: string | null;
+  progressCurrent: number;
+  progressTotal: number;
+  errorMessage: string | null;
+};
+
+export function StatusPoller({ jobId }: { jobId: string }) {
+  const router = useRouter();
+  const [job, setJob] = useState<JobStatusPayload | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function poll() {
+      const response = await fetch(`/api/jobs/${jobId}`, { cache: "no-store" });
+      const payload = await response.json();
+      if (cancelled || !payload.ok) {
+        return;
+      }
+
+      const nextJob = payload.data.job as JobStatusPayload;
+      setJob(nextJob);
+
+      if (nextJob.status === "awaiting_review") {
+        router.push(`/review/${jobId}`);
+      } else if (nextJob.status === "ready") {
+        router.push(`/download/${jobId}`);
+      }
+    }
+
+    void poll();
+    const interval = window.setInterval(() => void poll(), 5000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [jobId, router]);
+
+  if (!job) {
+    return <p className="text-slate-600">Checking current job status...</p>;
+  }
+
+  if (job.status === "error") {
+    return (
+      <p className="text-red-700">
+        Processing failed: {job.errorMessage ?? "Unknown error"}
+      </p>
+    );
+  }
+
+  return (
+    <p className="text-slate-600">
+      {job.phase ?? job.status} ({job.progressCurrent} / {job.progressTotal})
+    </p>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds polling from `/process/[jobId]` into `/review/[jobId]` and `/download/[jobId]` based on persisted job status.
- Adds `/api/jobs/[id]/descriptions` and `/api/jobs/[id]/commit` with profile ownership checks.
- Adds a review grid for generated alt text and a commit handoff to the Python processor rebuild endpoint.
- Adds a minimal `/download/[jobId]` ready-state placeholder until signed downloads land.

## Test plan
- `python scripts/check_invariants.py`
- `DIRECT_URL=postgresql://postgres:postgres@localhost:5432/postgres npm run prisma:generate`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high` (passes high threshold; reports existing moderate transitive findings only)

## Notes
- No PPTX parsing, Chroma, or Gemini logic moved to TypeScript.
- The download page intentionally does not create signed download URLs yet; that is the next slice.