### PR TITLE
Add auth and consent flow

### DIFF
--- a/docs/irb/consent-v1.md
+++ b/docs/irb/consent-v1.md
@@ -3,7 +3,7 @@
 > Pending manual confirmation: replace this placeholder with the IRB-approved
 > consent language before production cutover.
 >
-> Runtime copy: `nextjs/src/content/consent-v1.md`. Keep both files in sync
+> Runtime copy: `nextjs/src/content/consent.ts`. Keep both files in sync
 > until the final IRB-approved text lands.
 
 This tool helps generate accessibility descriptions for images in uploaded

--- a/docs/irb/consent-v1.md
+++ b/docs/irb/consent-v1.md
@@ -1,0 +1,16 @@
+# Consent to Participate
+
+> Pending manual confirmation: replace this placeholder with the IRB-approved
+> consent language before production cutover.
+
+This tool helps generate accessibility descriptions for images in uploaded
+PowerPoint presentations. The generated text is AI-assisted and may contain
+errors, omissions, or outdated information. Review all generated descriptions
+before using the rebuilt presentation.
+
+By continuing, you confirm that you understand:
+
+- Uploaded presentations are processed to generate accessibility descriptions.
+- AI-generated descriptions must be reviewed before use.
+- Your consent acceptance is recorded for audit purposes.
+- Final data retention and research-use language is pending IRB confirmation.

--- a/nextjs/src/app/auth/callback/route.ts
+++ b/nextjs/src/app/auth/callback/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { safeInternalRedirectPath } from "@/lib/redirects";
+import { createSupabaseMiddlewareClient } from "@/lib/supabase";
+
+export async function GET(request: NextRequest) {
+  const requestUrl = new URL(request.url);
+  const code = requestUrl.searchParams.get("code");
+  const next = safeInternalRedirectPath(requestUrl.searchParams.get("next"));
+  let response = NextResponse.redirect(new URL(next, request.url));
+
+  if (code) {
+    const supabase = createSupabaseMiddlewareClient(request, response);
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+    if (error) {
+      response = NextResponse.redirect(
+        new URL(`/auth/sign-in?message=${encodeURIComponent(error.message)}`, request.url),
+      );
+    }
+  }
+
+  return response;
+}

--- a/nextjs/src/app/auth/sign-in/page.tsx
+++ b/nextjs/src/app/auth/sign-in/page.tsx
@@ -1,0 +1,77 @@
+import { redirect } from "next/navigation";
+import { safeInternalRedirectPath } from "@/lib/redirects";
+import { createSupabaseServerClient } from "@/lib/supabase";
+
+type SignInPageProps = {
+  searchParams: Promise<{
+    redirectedFrom?: string;
+    message?: string;
+  }>;
+};
+
+async function signIn(formData: FormData) {
+  "use server";
+
+  const email = String(formData.get("email") ?? "");
+  const redirectedFrom = safeInternalRedirectPath(
+    String(formData.get("redirectedFrom") ?? "/upload"),
+  );
+  const supabase = await createSupabaseServerClient();
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  const callbackUrl = new URL("/auth/callback", appUrl);
+  callbackUrl.searchParams.set("next", redirectedFrom);
+
+  const { error } = await supabase.auth.signInWithOtp({
+    email,
+    options: {
+      emailRedirectTo: callbackUrl.toString(),
+    },
+  });
+
+  if (error) {
+    redirect(`/auth/sign-in?message=${encodeURIComponent(error.message)}`);
+  }
+
+  redirect("/auth/sign-in?message=Check your email for the sign-in link.");
+}
+
+export default async function SignInPage({ searchParams }: SignInPageProps) {
+  const params = await searchParams;
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-xl flex-col justify-center gap-8 px-6 py-16">
+      <div className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-wide text-blue-700">
+          Sign in
+        </p>
+        <h1 className="text-4xl font-bold tracking-tight text-slate-950">
+          Continue with email
+        </h1>
+        <p className="text-lg leading-8 text-slate-700">
+          Enter your email address and Supabase will send a magic link.
+        </p>
+      </div>
+
+      <form action={signIn} className="space-y-4 rounded-2xl border border-slate-200 p-6">
+        <input
+          name="redirectedFrom"
+          type="hidden"
+          value={safeInternalRedirectPath(params.redirectedFrom)}
+        />
+        <label className="block space-y-2">
+          <span className="font-semibold text-slate-950">Email</span>
+          <input
+            className="w-full rounded-lg border border-slate-300 p-3"
+            name="email"
+            required
+            type="email"
+          />
+        </label>
+        <button className="rounded-lg bg-blue-700 px-5 py-3 font-semibold text-white">
+          Send magic link
+        </button>
+        {params.message ? <p className="text-sm text-slate-700">{params.message}</p> : null}
+      </form>
+    </main>
+  );
+}

--- a/nextjs/src/app/consent/page.tsx
+++ b/nextjs/src/app/consent/page.tsx
@@ -1,0 +1,54 @@
+import { notFound, redirect } from "next/navigation";
+import { acceptConsent, CONSENT_VERSION, getConsentMarkdown } from "@/lib/consent";
+import { requireCurrentProfile } from "@/lib/auth";
+
+function markdownToParagraphs(markdown: string) {
+  return markdown
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter(Boolean);
+}
+
+export default async function ConsentPage() {
+  const profile = await requireCurrentProfile();
+  if (!profile) {
+    notFound();
+  }
+
+  if (profile.consentAcceptedAt && profile.consentVersion === CONSENT_VERSION) {
+    redirect("/upload");
+  }
+
+  const consentMarkdown = await getConsentMarkdown();
+  const blocks = markdownToParagraphs(consentMarkdown);
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col gap-8 px-6 py-16">
+      <div className="space-y-3">
+        <p className="text-sm font-semibold uppercase tracking-wide text-blue-700">
+          Consent
+        </p>
+        <h1 className="text-4xl font-bold tracking-tight text-slate-950">
+          Review consent before uploading
+        </h1>
+        <p className="text-lg leading-8 text-slate-700">
+          Consent version: `{CONSENT_VERSION}`
+        </p>
+      </div>
+
+      <article className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 text-slate-700 shadow-sm">
+        {blocks.map((block) => (
+          <p className="leading-7" key={block}>
+            {block.replace(/^#+\s*/, "").replace(/^>\s*/, "")}
+          </p>
+        ))}
+      </article>
+
+      <form action={acceptConsent}>
+        <button className="rounded-lg bg-blue-700 px-5 py-3 font-semibold text-white">
+          I consent and want to continue
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/nextjs/src/content/consent-v1.md
+++ b/nextjs/src/content/consent-v1.md
@@ -2,9 +2,6 @@
 
 > Pending manual confirmation: replace this placeholder with the IRB-approved
 > consent language before production cutover.
->
-> Runtime copy: `nextjs/src/content/consent-v1.md`. Keep both files in sync
-> until the final IRB-approved text lands.
 
 This tool helps generate accessibility descriptions for images in uploaded
 PowerPoint presentations. The generated text is AI-assisted and may contain

--- a/nextjs/src/content/consent.ts
+++ b/nextjs/src/content/consent.ts
@@ -1,4 +1,4 @@
-# Consent to Participate
+export const CONSENT_MARKDOWN = `# Consent to Participate
 
 > Pending manual confirmation: replace this placeholder with the IRB-approved
 > consent language before production cutover.
@@ -14,3 +14,4 @@ By continuing, you confirm that you understand:
 - AI-generated descriptions must be reviewed before use.
 - Your consent acceptance is recorded for audit purposes.
 - Final data retention and research-use language is pending IRB confirmation.
+`;

--- a/nextjs/src/lib/consent.ts
+++ b/nextjs/src/lib/consent.ts
@@ -1,0 +1,56 @@
+import { createHash } from "crypto";
+import { readFile } from "fs/promises";
+import path from "path";
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+import { requireCurrentProfile } from "@/lib/auth";
+import { prisma } from "@/lib/db";
+
+export const CONSENT_VERSION = "consent-v1";
+
+export async function getConsentMarkdown() {
+  return readFile(
+    path.join(process.cwd(), "..", "docs", "irb", `${CONSENT_VERSION}.md`),
+    "utf8",
+  );
+}
+
+function hashIp(ip: string) {
+  return createHash("sha256").update(ip).digest("hex");
+}
+
+export async function acceptConsent() {
+  "use server";
+
+  const profile = await requireCurrentProfile();
+  if (!profile) {
+    redirect("/auth/sign-in");
+  }
+
+  const headerStore = await headers();
+  const forwardedFor = headerStore.get("x-forwarded-for") ?? "";
+  const ip = forwardedFor.split(",")[0]?.trim() || "unknown";
+  const userAgent = headerStore.get("user-agent");
+  const acceptedAt = new Date();
+
+  await prisma.$transaction([
+    prisma.consentEvent.create({
+      data: {
+        profileId: profile.id,
+        acceptedAt,
+        consentVersion: CONSENT_VERSION,
+        ipHash: hashIp(ip),
+        userAgent,
+      },
+    }),
+    prisma.profile.update({
+      where: { id: profile.id },
+      data: {
+        consentAcceptedAt: acceptedAt,
+        consentVersion: CONSENT_VERSION,
+      },
+    }),
+  ]);
+
+  redirect("/upload");
+}

--- a/nextjs/src/lib/consent.ts
+++ b/nextjs/src/lib/consent.ts
@@ -10,7 +10,7 @@ export const CONSENT_VERSION = "consent-v1";
 
 export async function getConsentMarkdown() {
   return readFile(
-    path.join(process.cwd(), "..", "docs", "irb", `${CONSENT_VERSION}.md`),
+    path.join(process.cwd(), "src", "content", `${CONSENT_VERSION}.md`),
     "utf8",
   );
 }

--- a/nextjs/src/lib/consent.ts
+++ b/nextjs/src/lib/consent.ts
@@ -1,18 +1,14 @@
 import { createHash } from "crypto";
-import { readFile } from "fs/promises";
-import path from "path";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { requireCurrentProfile } from "@/lib/auth";
+import { CONSENT_MARKDOWN } from "@/content/consent";
 import { prisma } from "@/lib/db";
 
 export const CONSENT_VERSION = "consent-v1";
 
-export async function getConsentMarkdown() {
-  return readFile(
-    path.join(process.cwd(), "src", "content", `${CONSENT_VERSION}.md`),
-    "utf8",
-  );
+export function getConsentMarkdown() {
+  return CONSENT_MARKDOWN;
 }
 
 function hashIp(ip: string) {

--- a/nextjs/src/lib/redirects.ts
+++ b/nextjs/src/lib/redirects.ts
@@ -1,0 +1,7 @@
+export function safeInternalRedirectPath(value: string | null | undefined, fallback = "/upload") {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) {
+    return fallback;
+  }
+
+  return value;
+}


### PR DESCRIPTION
## Summary
- Adds Supabase magic-link sign-in and auth callback handling.
- Adds versioned consent content plus `/consent` with append-only `ConsentEvent` persistence and `Profile` consent updates.
- Adds safe internal redirect handling for magic-link callback targets.

## Test plan
- `python scripts/check_invariants.py`
- `DIRECT_URL=postgresql://postgres:postgres@localhost:5432/postgres npm run prisma:generate`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high` (passes high threshold; reports existing moderate transitive findings only)

## Notes
- `docs/irb/consent-v1.md` is intentionally marked pending manual confirmation and must be replaced with IRB-approved language before cutover.